### PR TITLE
ci: 基础 CI workflow（Node 20 · pnpm · lint/typecheck/build）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,30 @@ jobs:
           node-version: '20'
           cache: 'pnpm'
 
+      - name: Check if package.json exists
+        id: check_pkg
+        run: |
+          if [ -f package.json ]; then
+            echo "has_pkg=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_pkg=false" >> $GITHUB_OUTPUT
+            echo "::notice::No package.json yet — skipping install/lint/typecheck/build. This is expected on CI-only branches."
+          fi
+
       - name: Install dependencies
+        if: steps.check_pkg.outputs.has_pkg == 'true'
         run: pnpm install --frozen-lockfile
 
       - name: Lint
+        if: steps.check_pkg.outputs.has_pkg == 'true'
         run: pnpm lint
 
       - name: Typecheck
+        if: steps.check_pkg.outputs.has_pkg == 'true'
         run: pnpm typecheck
 
       - name: Build
+        if: steps.check_pkg.outputs.has_pkg == 'true'
         run: pnpm build
         env:
           # Ensure Next.js treats the workspace correctly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs when a PR gets new commits
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Lint · Typecheck · Build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        # Reads `packageManager` field from package.json
+
+      - name: Setup Node.js 20 LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Build
+        run: pnpm build
+        env:
+          # Ensure Next.js treats the workspace correctly
+          NEXT_TELEMETRY_DISABLED: '1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,16 +21,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        # Reads `packageManager` field from package.json
-
-      - name: Setup Node.js 20 LTS
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'pnpm'
-
       - name: Check if package.json exists
         id: check_pkg
         run: |
@@ -40,6 +30,19 @@ jobs:
             echo "has_pkg=false" >> $GITHUB_OUTPUT
             echo "::notice::No package.json yet — skipping install/lint/typecheck/build. This is expected on CI-only branches."
           fi
+
+      - name: Setup pnpm
+        if: steps.check_pkg.outputs.has_pkg == 'true'
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.15.4
+
+      - name: Setup Node.js 20 LTS
+        if: steps.check_pkg.outputs.has_pkg == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
 
       - name: Install dependencies
         if: steps.check_pkg.outputs.has_pkg == 'true'


### PR DESCRIPTION
## 变更

新增 `.github/workflows/ci.yml`，在 PR 和 main push 时触发。

### 步骤

1. Checkout
2. Setup pnpm（读 `packageManager` 字段）
3. Setup Node **20 LTS**（与 `engines` 对齐）
4. pnpm install --frozen-lockfile
5. pnpm lint
6. pnpm typecheck
7. pnpm build

### 为什么要先合这个 PR

PR #5（脚手架）在 Manus 沙箱环境里 build 失败，已列出 3 个可能的环境问题。这个 CI 用干净的 Node 20 + pnpm 环境验证 PR #5 的真实情况。

### 流程建议

1. 本 PR 合入 main
2. Manus 在 PR #5 上 rebase / merge main → 触发 CI
3. 根据 CI 输出决定 PR #5 是合入还是修复

Closes #3

### 领地

`.github/workflows/` 属于 Moss 领地（infra）。

cc @theathondmanus