### PR TITLE
fix(footer): 更新英国联系电话为 +44 (0)7345 169 054

### DIFF
--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -78,10 +78,10 @@ export default function Footer() {
                 enquiries@mediversityglobal.com
               </a>
               <a
-                href="tel:+447737398331"
+                href="tel:+447345169054"
                 className="text-gray-400 hover:text-white transition-colors no-underline block"
               >
-                +44 (0)7737 398 331
+                +44 (0)7345 169 054
               </a>
             </div>
           </div>


### PR DESCRIPTION
## 变更

Eric 反馈：旧号 `+44 (0)7737 398 331` 已停用，替换为新号码 `+44 (0)7345 169 054`。

### 改动

- `src/components/layout/Footer.tsx`：`tel:` 链接 + 显示文本同步更新

### 全站审计

```bash
grep -rn '7737398331\|7737 398 331' .
```

结果：旧号只在 Footer 出现 2 处，均已替换。其他位置（Header / Contact 页 / schema.org）目前没有电话字段。未来 Manus 如新增 Contact 页或结构化数据，请使用新号码。

### 类型

- [x] 🐛 修复

### 领地检查

- [x] Footer 是共享组件，但这是纯数据修复（号码变更），非视觉决策 → 合领地
- [x] 无技术栈变更

### 测试

号码替换，无功能影响。CI 走完即可合入。

cc @theathondmanus