### PR TITLE
fix(home-hero): H1 fluid font + whitespace-nowrap on all viewports

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -66,7 +66,7 @@ export default function HomePage() {
             <motion.h1
               variants={fadeInUp}
               custom={1}
-              className="font-display text-4xl md:text-5xl lg:text-[3.5rem] font-bold text-white leading-[1.15] mb-6 md:whitespace-nowrap"
+              className="font-display text-[clamp(1.75rem,7vw,3.5rem)] font-bold text-white leading-[1.15] mb-6 whitespace-nowrap"
             >
               {t("hero.title")}
             </motion.h1>


### PR DESCRIPTION
PR #37 加 md:whitespace-nowrap 但 owner 19:53 截图显示依然换行。

新方案: 字号 clamp(1.75rem, 7vw, 3.5rem) + 全屏 whitespace-nowrap。任何屏宽 H1 都一行。