### PR TITLE
fix(i18n): 补全 insightDetail.sourceLabel 翻译键

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -308,7 +308,8 @@
       "body": "Article content coming soon. This page will support rich text content in MDX format."
     },
     "related": "Related Articles",
-    "relatedEmpty": "No related articles yet"
+    "relatedEmpty": "No related articles yet",
+    "sourceLabel": "Source:"
   },
   "common": {
     "backToProgrammes": "Back to all programmes",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -308,7 +308,8 @@
       "body": "文章内容即将上线，敬请期待。此页面将支持 MDX 格式的富文本内容。"
     },
     "related": "相关文章",
-    "relatedEmpty": "暂无相关文章"
+    "relatedEmpty": "暂无相关文章",
+    "sourceLabel": "来源："
   },
   "common": {
     "backToProgrammes": "返回全部项目",


### PR DESCRIPTION
## 背景

5-16 redeploy 部署日志中报 `MISSING_MESSAGE: insightDetail.sourceLabel (zh-CN)` **8 次**（每篇 insights SSG 渲染都触发），build 没 fail（next-intl missing 是 warn 级），但 36 个 insights/[slug] SSG 页的源链接区会显示原始 key 字符串 `insightDetail.sourceLabel` 而不是 `来源：`。

## 改动

- `src/messages/zh-CN.json`: 加 `insightDetail.sourceLabel = '来源：'`
- `src/messages/en.json`: 加 `insightDetail.sourceLabel = 'Source:'`

## 代码引用

`src/app/[locale]/insights/[slug]/page.tsx:105` 调用 `t('sourceLabel')`，位于 `{article.source && ...}` 块，用作 "来源：<原文链接>" 的前缀。

## 影响

- 5 篇 insights 文章的源链接区（如有 source frontmatter）将正确显示 "来源：" / "Source:" 前缀
- 部署日志不再有 8 次 MISSING_MESSAGE warn

## 测试

- 本地 jq 验证两个 JSON 文件均含新字段（且现有字段未变）
- 改动仅添加新 key，与现有 JSON 完全向后兼容
- 待 staging redeploy 验证 MISSING warn 已消失
