### PR TITLE
feat(mednav): 印尼客户中医康复案例落地为主案例（4 阶段时间线）

### DIFF
--- a/content/pages/medical-navigator.json
+++ b/content/pages/medical-navigator.json
@@ -301,6 +301,70 @@
     "items": [
       {
         "type": {
+          "zh-CN": "海外术后中医康复",
+          "en": "Overseas TCM Post-operative Recovery"
+        },
+        "location": {
+          "zh-CN": "东南亚 · 印尼",
+          "en": "Southeast Asia · Indonesia"
+        },
+        "identity": {
+          "zh-CN": "印尼患者 · 血栓术后康复",
+          "en": "Indonesian patient · Post-thrombectomy rehabilitation"
+        },
+        "narrative": {
+          "zh-CN": "一位来自东南亚的患者在接受血栓切除术后，仍存在肢体功能恢复缓慢及生活自理能力受限的问题。由于身体条件不适合长途跨境治疗，而当地优质中医康复资源相对有限，患者希望获得更加可持续、可执行的康复支持方案。我们以「先评估、再匹配」为核心，围绕本地化可行性、康复连续性与长期执行稳定性，为患者设计了基于本地合法执业中医专家的多阶段康复路径。",
+          "en": "A patient from Southeast Asia, following thrombectomy treatment, continued to experience slow functional recovery and limitations in daily independence. With long-distance travel deemed unsuitable and limited high-quality TCM rehabilitation resources locally, the patient sought a more sustainable and practical support pathway. Centred on 'assessment before referral', we designed a multi-stage rehabilitation pathway with locally licensed TCM specialists — prioritising local feasibility, continuity of care, and long-term sustainability."
+        },
+        "quote": {
+          "zh-CN": "频繁跨境奔波并不是答案——稳定、本地化、可持续的康复支持，才是患者真正需要的。",
+          "en": "Frequent international travel wasn't the answer — stable, local, sustainable rehabilitation support was what the patient truly needed."
+        },
+        "milestones": [
+          {
+            "date": {
+              "zh-CN": "第 1 阶段 · 联系与评估",
+              "en": "Stage 1 · Initial Contact & Assessment"
+            },
+            "event": {
+              "zh-CN": "了解患者既往血栓切除治疗、当前身体状态及长期恢复目标，判断频繁跨境治疗并非最优方案。",
+              "en": "Reviewed the patient's thrombectomy history, current condition, and long-term recovery goals; assessed that frequent cross-border treatment was not the optimal pathway."
+            }
+          },
+          {
+            "date": {
+              "zh-CN": "第 2 阶段 · 路径设计与对接",
+              "en": "Stage 2 · Pathway Design & Provider Matching"
+            },
+            "event": {
+              "zh-CN": "围绕本地化可行性、康复连续性与长期执行稳定性进行路径设计，对接当地具备合法执业资质且具有海外临床服务经验的中医康复专家。",
+              "en": "Designed a pathway centred on local feasibility, continuity of care, and long-term sustainability; matched the patient with locally licensed TCM rehabilitation specialists with international clinical experience."
+            }
+          },
+          {
+            "date": {
+              "zh-CN": "第 3 阶段 · 分阶段康复支持",
+              "en": "Stage 3 · Phased Rehabilitation Support"
+            },
+            "event": {
+              "zh-CN": "针灸、推拿及阶段性康复调理同步开展；建立阶段性恢复评估机制，根据反馈动态调整康复重点。",
+              "en": "Acupuncture, therapeutic massage and phased rehabilitation initiated; ongoing recovery assessments established with adaptive focus based on feedback."
+            }
+          },
+          {
+            "date": {
+              "zh-CN": "第 4 阶段 · 长期持续跟进",
+              "en": "Stage 4 · Ongoing Long-term Follow-up"
+            },
+            "event": {
+              "zh-CN": "持续沟通与进度跟踪、长期居家康复建议，建立更加稳定的后续健康管理节奏，无需频繁跨境奔波。",
+              "en": "Continued communication and progress tracking, long-term home rehabilitation guidance, and a sustainable ongoing health management routine — without requiring repeated international travel."
+            }
+          }
+        ]
+      },
+      {
+        "type": {
           "zh-CN": "海外急症转诊",
           "en": "Overseas Emergency Referral"
         },

--- a/src/app/[locale]/medical-navigator/page.tsx
+++ b/src/app/[locale]/medical-navigator/page.tsx
@@ -24,12 +24,16 @@ import CaseShowcase, { type CaseStudy } from "@/components/medical-navigator/Cas
 import content from "../../../../content/pages/medical-navigator.json";
 
 /* ── Map JSON case items to CaseStudy shape ── */
-const caseStudies: CaseStudy[] = content.cases.items.map((item, idx) => ({
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const caseStudies: CaseStudy[] = content.cases.items.map((item: any, idx: number) => ({
   id: `case-${idx}`,
   type: item.type,
   narrative: item.narrative,
   quote: item.quote,
   identity: item.identity,
+  milestones: item.milestones,
+  location: item.location,
+  image: item.image,
   featured: idx === 0,
 }));
 


### PR DESCRIPTION
## 背景

Eric 在 5-18 版本网站内容文档（MVG新版网站内容文档-20260518_1）末尾补充了印尼客户中医康复案例的完整内容（约 60 段双语），用于 MedNav 客户案例区的**主案例**位置。

## 印尼案例核心信息

| 字段 | 内容 |
|---|---|
| **类型** | 海外术后中医康复 |
| **地点** | 东南亚 · 印尼 |
| **客户** | 印尼患者 · 血栓术后康复 |
| **痛点** | 身体条件不适合长途跨境治疗 + 本地优质中医康复资源有限 |
| **核心方法论** | 「先评估、再匹配」 |
| **解决路径** | 本地合法执业 TCM 专家 + 多阶段康复路径 |

### 4 阶段服务时间线（milestones）

1. **第 1 阶段 · 联系与评估** —— 了解既往血栓切除治疗 + 判断跨境治疗非最优
2. **第 2 阶段 · 路径设计与对接** —— 围绕本地化可行性 + 对接当地合法执业 TCM 专家
3. **第 3 阶段 · 分阶段康复支持** —— 针灸/推拿/调理 + 阶段性恢复评估
4. **第 4 阶段 · 长期持续跟进** —— 持续沟通 + 居家康复建议

## 改动文件

### `content/pages/medical-navigator.json`
- `cases.items[0]` 插入印尼案例（自动 `featured`，因 page.tsx 用 `idx===0` 判断主案例）
- 包含完整 4 个 milestones 时间线
- 现有 3 个虚构案例（张女士/李先生/王女士）保留为轮播子案例占位

### `src/app/[locale]/medical-navigator/page.tsx`
- CaseShowcase mapping 透传 `milestones`、`location`、`image` 字段
- 这是 PR #50 Manus 标注的 "schema ready, awaiting owner content" 部分

## 视觉效果（CaseShowcase 主案例区）

```
┌─────────────────────────────────────────────┐
│  ████  顶部 gradient                         │
│                                              │
│  [海外术后中医康复]  📍 东南亚 · 印尼          │
│                                              │
│  narrative（约 200 字）...                    │
│                                              │
│  ┌─ 引号块 ─────────────────┐                │
│  │ "频繁跨境奔波并不是答案…"  │                │
│  │ — 印尼患者 · 血栓术后康复    │                │
│  └─────────────────────────┘                │
│                                              │
│  📅 服务时间线                                │
│  ● 第 1 阶段 · 联系与评估                    │
│  │  了解既往治疗、判断…                       │
│  ● 第 2 阶段 · 路径设计与对接                │
│  │  围绕本地化可行性…                          │
│  ● 第 3 阶段 · 分阶段康复支持                │
│  │  针灸、推拿…                               │
│  ● 第 4 阶段 · 长期持续跟进                  │
│     持续沟通…                                 │
│                                              │
│                          ← →  缩略导航箭头   │
└─────────────────────────────────────────────┘

下方缩略导航条（占位）：
[1] 印尼 [2] 张女士 [3] 李先生 [4] 王女士
```

## 不在本 PR 范围

- **印尼案例配图**：`image` 字段当前空，等 Manus 配场景图（不用课堂照/PPT/老师照，按 PR #41 视觉标准）
- **子页面路由 `/medical-navigator/cases/<slug>`**：CaseShowcase 内嵌时间轴已足够展示，暂不需要子页面
- **替换 3 个占位虚构案例**：等章逊给真实案例

## 测试

- jq empty 验证 JSON 语法 ✅
- 双语字段（zh-CN/en）成对更新 ✅
- TypeScript 类型用 eslint inline disable 处理（content JSON 是 untyped import）
- 待 staging redeploy 验证 CaseShowcase 时间轴渲染
