### PR TITLE
fix(i18n): '在线课程' 改 '在授课程' + i18n 化硬编码

### DIFF
--- a/src/app/[locale]/programmes/page.tsx
+++ b/src/app/[locale]/programmes/page.tsx
@@ -185,7 +185,7 @@ export default function ProgrammesHubPage() {
                                   {pillar.activeCourses}
                                 </span>
                                 <span className="text-xs text-[#8A889A] ml-1.5">
-                                  门在线课程
+                                  {t("activeCourses")}
                                 </span>
                               </div>
                               <div className="w-px h-6 bg-[#E3E5EC]" />
@@ -194,7 +194,7 @@ export default function ProgrammesHubPage() {
                                   {pillar.futureCourses}
                                 </span>
                                 <span className="text-xs text-[#8A889A] ml-1.5">
-                                  门规划中
+                                  {t("futureCoursesShort")}
                                 </span>
                               </div>
                             </div>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -118,7 +118,8 @@
         "title": "Professional Development & Medical Humanities",
         "desc": "Medical humanities, leadership and cross-cultural communication competency"
       }
-    }
+    },
+    "futureCoursesShort": "planned"
   },
   "programmes": {
     "medicalEnglish": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -99,7 +99,7 @@
   "programmesHub": {
     "title": "培训项目",
     "subtitle": "四大板块覆盖医疗专业人士国际化发展的全部核心需求",
-    "activeCourses": "门在线课程",
+    "activeCourses": "门在授课程",
     "explore": "了解更多",
     "pillars": {
       "medicalEnglish": {
@@ -118,7 +118,8 @@
         "title": "职业发展与医学人文",
         "desc": "医学人文素养、领导力与跨文化沟通能力提升"
       }
-    }
+    },
+    "futureCoursesShort": "门规划中"
   },
   "programmes": {
     "medicalEnglish": {
@@ -313,7 +314,7 @@
   },
   "common": {
     "backToProgrammes": "返回全部项目",
-    "activeCourses": "门在线课程",
+    "activeCourses": "门在授课程",
     "futureCourses": "门规划中课程",
     "futureProgrammes": "规划中的课程",
     "viewDetails": "查看详情"


### PR DESCRIPTION
## 章逊反馈

programmes hub 4 个 pillar 卡片上 '5 门**在线**课程' 应该是 '5 门**在授**课程'（正在授课的语义，不是'在线'）。

## 改动

| 文件 | 改动 |
|---|---|
| messages/zh-CN.json | 'programmesHub.activeCourses' + 'common.activeCourses' 都改成 '门在授课程'；新增 'programmesHub.futureCoursesShort: 门规划中' |
| messages/en.json | 保留 'active courses'（语义匹配）；新增 'futureCoursesShort: planned' |
| programmes/page.tsx | 两处硬编码（'门在线课程' / '门规划中'）改成 i18n key 引用 |

## 顺手优化

把 page.tsx 的硬编码字符串改成 `t()` 引用，未来再改文案只需改 messages JSON，不再需要碰组件代码。

## 影响

- /programmes Hub 4 个 pillar 卡片
- /programmes/medical-english / observership / research-academic / humanities 4 个 pillar 子页（PillarLandingPage 共享组件）

## 测试

- jq empty 验证 JSON ✅
- 待 staging redeploy 验证文案