### PR TITLE
fix(nav): 导航命名对齐新版基线（培训项目→国际医学教育 / 洞察→洞察与案例）

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,8 +1,8 @@
 {
   "nav": {
-    "programmes": "Programmes",
-    "medicalNavigator": "Medical Navigator",
-    "insights": "Insights",
+    "programmes": "International Medical Education",
+    "medicalNavigator": "Cross-border Medical Navigation",
+    "insights": "Insights & Cases",
     "about": "About",
     "contact": "Contact",
     "viewAllProgrammes": "View all programmes",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -1,11 +1,11 @@
 {
   "nav": {
-    "programmes": "培训项目",
-    "medicalNavigator": "医疗导航",
-    "insights": "洞察",
+    "programmes": "国际医学教育",
+    "medicalNavigator": "跨境医疗导航",
+    "insights": "洞察与案例",
     "about": "关于我们",
     "contact": "联系我们",
-    "viewAllProgrammes": "查看全部项目",
+    "viewAllProgrammes": "查看全部国际医学教育项目",
     "pillars": {
       "medicalEnglish": "医学英语与沟通",
       "medicalEnglishDesc": "从基础英语到临床实战，全方位提升医疗英语能力",


### PR DESCRIPTION
## 章逊反馈

1. **培训项目** 按 Eric 文档命名改成 **国际医学教育**
2. **洞察** 因为有 Case Study，建议改成 **洞察与案例** 以告诉用户存在这块内容

顺手把 **医疗导航** 对齐 M3 (PR #49) 基线改成 **跨境医疗导航**（之前漏改）。

## 改动

| zh-CN | 旧 | 新 |
|---|---|---|
| nav.programmes | 培训项目 | **国际医学教育** |
| nav.medicalNavigator | 医疗导航 | **跨境医疗导航** |
| nav.insights | 洞察 | **洞察与案例** |
| nav.viewAllProgrammes | 查看全部项目 | 查看全部国际医学教育项目 |

| en | 旧 | 新 |
|---|---|---|
| nav.programmes | Programmes | **International Medical Education** |
| nav.medicalNavigator | Medical Navigator | **Cross-border Medical Navigation** |
| nav.insights | Insights | **Insights & Cases** |

## 全站命名基线状态

到本 PR 后所有引用都同步：

- ✅ home.businessLines (M3 PR #49)
- ✅ home.hero badge (M3 PR #49)
- ✅ medical-navigator 全文 (M4 PR #51)
- ✅ nav (本 PR)

## 视觉提醒 @theathondmanus

中文 nav 命名变长（4字 → 6字），英文版更长（28 字符）。请看 staging 效果，如视觉拥挤再调整（或考虑英文 nav 用简称如 'Education' / 'Navigator' / 'Insights & Cases'）。