### PR TITLE
feat(programmes): M6 — 8 门课按 OET 范例落地

### DIFF
--- a/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
@@ -1,0 +1,120 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-humanities-and-communication-skills",
+  category: "humanities",
+  subcategory: "medical-humanities",
+  title: "Medical Humanities and Communication Skills",
+  shortDescription: "Empathy-driven care — core skills for healthcare professionals",
+  metaDescription: "Medical Humanities and Communication Skills - Empathy-driven care — core skills for healthcare professionals",
+  duration: "6 lessons (2 hours each)",
+  audience: ["Doctors", "Healthcare Practitioners"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "Medical Humanities and Communication Skills",
+    lede: "Empathy-driven care — core skills for healthcare professionals",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-humanities-and-communication-skills.webp",
+    imageAlt: "Medical Humanities and Communication Skills - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "本课程旨在帮助医疗从业者掌握核心沟通技巧与人文素养，提供以患者为中心的医疗服务。除专业知 识外，课程聚焦共情能力、医学伦理、患者心理、跨文化意识及医患关系管理。学员将通过沉浸式实 践活动，掌握更具温度、专业性与适应性的沟通技巧，从而在复杂临床场景中实现高效共情与精准决策。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "培养人文价值观与以患者为中心的思维模式",
+          description: "",
+        },
+        {
+          title: "通过高效医患沟通建立信任",
+          description: "",
+        },
+        {
+          title: "运用跨文化技能服务多元患者群体",
+          description: "",
+        },
+        {
+          title: "在临床实践中强化同理心与情商",
+          description: "",
+        },
+        {
+          title: "运用医学伦理进行共情与伦理决策",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Teaching Methods",
+      items: [
+        {
+          title: "高仿真案例教学",
+          description: "",
+        },
+        {
+          title: "角色扮演模拟训练",
+          description: "",
+        },
+        {
+          title: "互动式深度对话",
+          description: "",
+        },
+        {
+          title: "结构化实践任务",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 医学人文与职业身份认同",
+          description: "1. 医学人文与职业身份认同",
+        },
+        {
+          title: "2. 医患沟通技巧",
+          description: "2. 医患沟通技巧",
+        },
+        {
+          title: "3. 患者心理与情绪支持",
+          description: "3. 患者心理与情绪支持",
+        },
+        {
+          title: "4. 医学伦理与共情照护",
+          description: "4. 医学伦理与共情照护",
+        },
+        {
+          title: "5. 跨文化沟通",
+          description: "5. 跨文化沟通",
+        },
+        {
+          title: "6. 医疗从业者的身心健康",
+          description: "6. 医疗从业者的身心健康",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical Humanities and Communication Skills\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
@@ -1,0 +1,144 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-humanities-and-general-practice-literacy",
+  category: "humanities",
+  subcategory: "medical-humanities",
+  title: "Medical Humanities and General Practice Literacy",
+  shortDescription: "Reading disease with expertise, delivering care through dialogue",
+  metaDescription: "Medical Humanities and General Practice Literacy - Reading disease with expertise, delivering care through dialogue",
+  duration: "10 lessons (2 hours each)",
+  audience: ["General Practitioners", "Medical Humanities Learners"],
+  featured: false,
+  order: 10,
+  status: "published",
+
+  hero: {
+    headline: "Medical Humanities and General Practice Literacy",
+    lede: "Reading disease with expertise, delivering care through dialogue",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-humanities-and-general-practice-literacy.webp",
+    imageAlt: "Medical Humanities and General Practice Literacy - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "本课程旨在为医学生和医疗从业者提供医学人文知识、全科医学思维及实用沟通技能。通过真实案例 研讨、高仿真情景模拟及跨学科协作训练，学员将系统掌握以患者为中心的诊疗思维模式，提升伦理 敏感度与沟通效能。课程聚焦全球医疗体系中的全科医学角色，结合国际前沿经验与中国基层医疗实 际需求，培养学员在复杂医疗场景下的临床推理能力、跨学科协作意识及职业韧性，助力其成为兼具 技术精湛与人文温度的复合型医疗人才。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "通过医学人文核心理念培养人文关怀",
+          description: "",
+        },
+        {
+          title: "在临床决策中应用医学伦理",
+          description: "",
+        },
+        {
+          title: "提升医患沟通以增强信任与服务质量",
+          description: "",
+        },
+        {
+          title: "理解全科医学在医疗体系中的原则与作用",
+          description: "",
+        },
+        {
+          title: "培养跨学科临床思维",
+          description: "",
+        },
+        {
+          title: "通过案例与实践强化临床推理与应变能力",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Teaching Methods",
+      items: [
+        {
+          title: "案例分析",
+          description: "",
+        },
+        {
+          title: "情景模拟",
+          description: "",
+        },
+        {
+          title: "跨学科阅读",
+          description: "",
+        },
+        {
+          title: "实践练习",
+          description: "",
+        },
+        {
+          title: "小组讨论",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 医学人文导论：医学不仅是科学，更是人文",
+          description: "1. 医学人文导论：医学不仅是科学，更是人文",
+        },
+        {
+          title: "2. 医学伦理与临床决策：伦理挑战与价值判断",
+          description: "2. 医学伦理与临床决策：伦理挑战与价值判断",
+        },
+        {
+          title: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
+          description: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
+        },
+        {
+          title: "4. 全科医学的基础与全球视角：全科医生的核心能力",
+          description: "4. 全科医学的基础与全球视角：全科医生的核心能力",
+        },
+        {
+          title: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
+          description: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
+        },
+        {
+          title: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
+          description: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
+        },
+        {
+          title: "7. 全科医学临床实践：初步诊断与综合评估",
+          description: "7. 全科医学临床实践：初步诊断与综合评估",
+        },
+        {
+          title: "8. 特殊人群的医疗照护：提供个体化服务",
+          description: "8. 特殊人群的医疗照护：提供个体化服务",
+        },
+        {
+          title: "9. 全科医学见习：亲身体验基层医疗",
+          description: "9. 全科医学见习：亲身体验基层医疗",
+        },
+        {
+          title: "10. 总结与实践应用：案例研究与职业发展规划",
+          description: "10. 总结与实践应用：案例研究与职业发展规划",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical Humanities and General Practice Literacy\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
@@ -1,0 +1,120 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-humanities-and-communication-skills",
+  category: "humanities",
+  subcategory: "medical-humanities",
+  title: "医学人文与沟通技能",
+  shortDescription: "提升共情照护：赋能医疗从业者的核心技能",
+  metaDescription: "医学人文与沟通技能 - 提升共情照护：赋能医疗从业者的核心技能",
+  duration: "6 节课（每节 2 小时）",
+  audience: ["医生", "医护人员"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "医学人文与沟通技能",
+    lede: "提升共情照护：赋能医疗从业者的核心技能",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-humanities-and-communication-skills.webp",
+    imageAlt: "医学人文与沟通技能 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "本课程旨在帮助医疗从业者掌握核心沟通技巧与人文素养，提供以患者为中心的医疗服务。除专业知 识外，课程聚焦共情能力、医学伦理、患者心理、跨文化意识及医患关系管理。学员将通过沉浸式实 践活动，掌握更具温度、专业性与适应性的沟通技巧，从而在复杂临床场景中实现高效共情与精准决策。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "培养人文价值观与以患者为中心的思维模式",
+          description: "",
+        },
+        {
+          title: "通过高效医患沟通建立信任",
+          description: "",
+        },
+        {
+          title: "运用跨文化技能服务多元患者群体",
+          description: "",
+        },
+        {
+          title: "在临床实践中强化同理心与情商",
+          description: "",
+        },
+        {
+          title: "运用医学伦理进行共情与伦理决策",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "教学方法",
+      items: [
+        {
+          title: "高仿真案例教学",
+          description: "",
+        },
+        {
+          title: "角色扮演模拟训练",
+          description: "",
+        },
+        {
+          title: "互动式深度对话",
+          description: "",
+        },
+        {
+          title: "结构化实践任务",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 医学人文与职业身份认同",
+          description: "1. 医学人文与职业身份认同",
+        },
+        {
+          title: "2. 医患沟通技巧",
+          description: "2. 医患沟通技巧",
+        },
+        {
+          title: "3. 患者心理与情绪支持",
+          description: "3. 患者心理与情绪支持",
+        },
+        {
+          title: "4. 医学伦理与共情照护",
+          description: "4. 医学伦理与共情照护",
+        },
+        {
+          title: "5. 跨文化沟通",
+          description: "5. 跨文化沟通",
+        },
+        {
+          title: "6. 医疗从业者的身心健康",
+          description: "6. 医疗从业者的身心健康",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「医学人文与沟通技能」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
@@ -1,0 +1,144 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-humanities-and-general-practice-literacy",
+  category: "humanities",
+  subcategory: "medical-humanities",
+  title: "医学人文与全科医学素养",
+  shortDescription: "用专业解读疾病，用对话传递关怀",
+  metaDescription: "医学人文与全科医学素养 - 用专业解读疾病，用对话传递关怀",
+  duration: "10 节课（每节 2 小时）",
+  audience: ["全科医生", "医疗人文学习者"],
+  featured: false,
+  order: 10,
+  status: "published",
+
+  hero: {
+    headline: "医学人文与全科医学素养",
+    lede: "用专业解读疾病，用对话传递关怀",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-humanities-and-general-practice-literacy.webp",
+    imageAlt: "医学人文与全科医学素养 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "本课程旨在为医学生和医疗从业者提供医学人文知识、全科医学思维及实用沟通技能。通过真实案例 研讨、高仿真情景模拟及跨学科协作训练，学员将系统掌握以患者为中心的诊疗思维模式，提升伦理 敏感度与沟通效能。课程聚焦全球医疗体系中的全科医学角色，结合国际前沿经验与中国基层医疗实 际需求，培养学员在复杂医疗场景下的临床推理能力、跨学科协作意识及职业韧性，助力其成为兼具 技术精湛与人文温度的复合型医疗人才。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "通过医学人文核心理念培养人文关怀",
+          description: "",
+        },
+        {
+          title: "在临床决策中应用医学伦理",
+          description: "",
+        },
+        {
+          title: "提升医患沟通以增强信任与服务质量",
+          description: "",
+        },
+        {
+          title: "理解全科医学在医疗体系中的原则与作用",
+          description: "",
+        },
+        {
+          title: "培养跨学科临床思维",
+          description: "",
+        },
+        {
+          title: "通过案例与实践强化临床推理与应变能力",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "教学方法",
+      items: [
+        {
+          title: "案例分析",
+          description: "",
+        },
+        {
+          title: "情景模拟",
+          description: "",
+        },
+        {
+          title: "跨学科阅读",
+          description: "",
+        },
+        {
+          title: "实践练习",
+          description: "",
+        },
+        {
+          title: "小组讨论",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 医学人文导论：医学不仅是科学，更是人文",
+          description: "1. 医学人文导论：医学不仅是科学，更是人文",
+        },
+        {
+          title: "2. 医学伦理与临床决策：伦理挑战与价值判断",
+          description: "2. 医学伦理与临床决策：伦理挑战与价值判断",
+        },
+        {
+          title: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
+          description: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
+        },
+        {
+          title: "4. 全科医学的基础与全球视角：全科医生的核心能力",
+          description: "4. 全科医学的基础与全球视角：全科医生的核心能力",
+        },
+        {
+          title: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
+          description: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
+        },
+        {
+          title: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
+          description: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
+        },
+        {
+          title: "7. 全科医学临床实践：初步诊断与综合评估",
+          description: "7. 全科医学临床实践：初步诊断与综合评估",
+        },
+        {
+          title: "8. 特殊人群的医疗照护：提供个体化服务",
+          description: "8. 特殊人群的医疗照护：提供个体化服务",
+        },
+        {
+          title: "9. 全科医学见习：亲身体验基层医疗",
+          description: "9. 全科医学见习：亲身体验基层医疗",
+        },
+        {
+          title: "10. 总结与实践应用：案例研究与职业发展规划",
+          description: "10. 总结与实践应用：案例研究与职业发展规划",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「医学人文与全科医学素养」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/en/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/en/medical-english-for-doctors.ts
@@ -1,0 +1,194 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-english-for-doctors",
+  category: "medical-english",
+  subcategory: "clinical",
+  title: "Medical English for Doctors",
+  shortDescription: "Language and Communication Skills Programme for Healthcare Professionals",
+  metaDescription: "Medical English for Doctors - Language and Communication Skills Programme for Healthcare Professionals",
+  duration: "12 weeks",
+  audience: ["Doctors", "Medical Professionals"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "Medical English for Doctors",
+    lede: "Language and Communication Skills Programme for Healthcare Professionals",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-english-for-doctors.webp",
+    imageAlt: "Medical English for Doctors - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "以职业英语考试（OET）为基础，课程重点关注真实医疗情境，培养医生自信沟通能力和跨文化意识， 助力提供优质医疗服务。参与者将学会与患者有效互动、与多学科团队协作、管理专业通信， 并对全球医学研究做出贡献。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "掌握医学术语：熟练运用专业医学词汇，确保精准的医患沟通",
+          description: "",
+        },
+        {
+          title: "提升临床互动：具备提问、描述、指导的能力，开展高效的医患交流",
+          description: "",
+        },
+        {
+          title: "改善患者咨询：掌握访谈技巧，倾听患者需求，提供专业医疗建议",
+          description: "",
+        },
+        {
+          title: "加强文档报告：准确撰写医学报告，规范记录患者信息",
+          description: "",
+        },
+        {
+          title: "连接全球医疗：参与国际研究合作，为医学发展贡献力量",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Teaching Methods",
+      items: [
+        {
+          title: "互动教学与合作学习",
+          description: "",
+        },
+        {
+          title: "角色扮演、模拟、案例分析",
+          description: "",
+        },
+        {
+          title: "OET 考试导向练习",
+          description: "",
+        },
+        {
+          title: "小组讨论、同行反馈",
+          description: "",
+        },
+        {
+          title: "多媒体辅助教学",
+          description: "",
+        },
+        {
+          title: "社区互动支持",
+          description: "",
+        },
+        {
+          title: "导师指导",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Key Features",
+      items: [
+        {
+          title: "全面定制化学习路径",
+          description: "",
+        },
+        {
+          title: "融入国际标准",
+          description: "",
+        },
+        {
+          title: "互动支持式学习",
+          description: "",
+        },
+        {
+          title: "文化敏感沟通",
+          description: "",
+        },
+        {
+          title: "实用专业导向",
+          description: "",
+        },
+        {
+          title: "持续跟踪进步",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "基础知识",
+          description: "基础知识",
+        },
+        {
+          title: "医学与辅助医学人员与场所",
+          description: "医学与辅助医学人员与场所",
+        },
+        {
+          title: "教育与培训",
+          description: "教育与培训",
+        },
+        {
+          title: "系统、疾病与症状（20 个子模块）",
+          description: "系统、疾病与症状（20 个子模块）",
+        },
+        {
+          title: "检查",
+          description: "检查",
+        },
+        {
+          title: "治疗",
+          description: "治疗",
+        },
+        {
+          title: "预防",
+          description: "预防",
+        },
+        {
+          title: "流行病学",
+          description: "流行病学",
+        },
+        {
+          title: "伦理学",
+          description: "伦理学",
+        },
+        {
+          title: "研究",
+          description: "研究",
+        },
+        {
+          title: "采集病史",
+          description: "采集病史",
+        },
+        {
+          title: "检查（临床）",
+          description: "检查（临床）",
+        },
+        {
+          title: "解释",
+          description: "解释",
+        },
+        {
+          title: "展示",
+          description: "展示",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical English for Doctors\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/en/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/en/medical-english-for-nurses.ts
@@ -1,0 +1,186 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-english-for-nurses",
+  category: "medical-english",
+  subcategory: "clinical",
+  title: "Medical English for Nurses",
+  shortDescription: "An advanced, practice-oriented 50-lesson programme tailored for healthcare professionals",
+  metaDescription: "Medical English for Nurses - An advanced, practice-oriented 50-lesson programme tailored for healthcare professionals",
+  duration: "50 lessons",
+  audience: ["Nurses", "Nursing Professionals"],
+  featured: false,
+  order: 30,
+  status: "published",
+
+  hero: {
+    headline: "Medical English for Nurses",
+    lede: "An advanced, practice-oriented 50-lesson programme tailored for healthcare professionals",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-english-for-nurses.webp",
+    imageAlt: "Medical English for Nurses - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "护士医学英语课程是一门专为护士设计的专业课程，旨在提升其在英语医疗环境中有效进行患者护理 和协作所需的沟通技巧和医学词汇。该课程围绕职业英语测试（OET）结构，为护士提供日常与患者、 同事及其他医疗专业人士互动所需的实用语言技能。课程精心策划，帮助护士增强专业能力，自信应 对医疗场景，提升职业表现。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "医学术语发展：全面掌握医学术语及其在临床中的应用",
+          description: "",
+        },
+        {
+          title: "提升临床沟通技能：通过职业英语测试（OET）材料提高护理场景中的听、说、读、写能力",
+          description: "",
+        },
+        {
+          title: "改善患者沟通：在患者评估、健康检查和紧急情况下促进有效沟通",
+          description: "",
+        },
+        {
+          title: "增强患者护理中的能力与同理心：培养准确且富有同理心的患者教育和治疗信息传达能力",
+          description: "",
+        },
+        {
+          title: "强化文档与报告能力：掌握医疗环境中所需的高级英语结构，以实现清晰的文档与报告",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Teaching Methods",
+      items: [
+        {
+          title: "互动与协作学习",
+          description: "",
+        },
+        {
+          title: "角色扮演、模拟与案例分析",
+          description: "",
+        },
+        {
+          title: "基于 OET 的结构化练习",
+          description: "",
+        },
+        {
+          title: "小组讨论与互评",
+          description: "",
+        },
+        {
+          title: "多媒体资料",
+          description: "",
+        },
+        {
+          title: "社区支持",
+          description: "",
+        },
+        {
+          title: "辅导与指导",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Key Features",
+      items: [
+        {
+          title: "全面且个性化的学习路径",
+          description: "",
+        },
+        {
+          title: "国际认可标准的整合",
+          description: "",
+        },
+        {
+          title: "互动学习与支持性环境",
+          description: "",
+        },
+        {
+          title: "文化敏感与有效沟通",
+          description: "",
+        },
+        {
+          title: "实用、相关且专业导向",
+          description: "",
+        },
+        {
+          title: "持续进步跟踪",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "基础知识",
+          description: "基础知识",
+        },
+        {
+          title: "医学与辅助医学人员与场所",
+          description: "医学与辅助医学人员与场所",
+        },
+        {
+          title: "教育与培训",
+          description: "教育与培训",
+        },
+        {
+          title: "系统、疾病与症状（20 个子模块）",
+          description: "系统、疾病与症状（20 个子模块）",
+        },
+        {
+          title: "检查",
+          description: "检查",
+        },
+        {
+          title: "治疗",
+          description: "治疗",
+        },
+        {
+          title: "预防",
+          description: "预防",
+        },
+        {
+          title: "流行病学",
+          description: "流行病学",
+        },
+        {
+          title: "伦理学",
+          description: "伦理学",
+        },
+        {
+          title: "采集病史",
+          description: "采集病史",
+        },
+        {
+          title: "检查（临床）",
+          description: "检查（临床）",
+        },
+        {
+          title: "解释",
+          description: "解释",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical English for Nurses\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/en/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/en/pre-departure-medical-english.ts
@@ -1,0 +1,160 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "pre-departure-medical-english",
+  category: "medical-english",
+  subcategory: "global-mobility",
+  title: "Pre-Departure Medical English",
+  shortDescription: "A 12-week intensive language programme for healthcare professionals preparing for overseas clinical placement",
+  metaDescription: "Pre-Departure Medical English - A 12-week intensive language programme for healthcare professionals preparing for overseas clinical placement",
+  duration: "12 weeks",
+  audience: ["Pre-departure Healthcare Professionals", "Overseas Bound Learners"],
+  featured: false,
+  order: 40,
+  status: "published",
+
+  hero: {
+    headline: "Pre-Departure Medical English",
+    lede: "A 12-week intensive language programme for healthcare professionals preparing for overseas clinical placement",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/pre-departure-medical-english.webp",
+    imageAlt: "Pre-Departure Medical English - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "课程旨在帮助学员掌握在国际医疗环境中所需的沟通技巧和文化敏感度，提升他们在不同医疗场景中 的自信表现。通过实际操作与理论结合，学员将学会在多文化背景下高效地与患者、同事及其他医疗 团队成员进行交流。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "真实情境模拟",
+          description: "本课程将实际医疗场景引入课堂，确保学员可以身临其境地体验跨文化沟通的挑战和解决方案",
+        },
+        {
+          title: "以患者为中心的沟通框架",
+          description: "学员将学习并应用剑桥-卡尔加里指南，优化对患者咨询服务，确保信息清晰传达并展现同理心",
+        },
+        {
+          title: "多元化学习体验",
+          description: "课程结合互动讨论、实践操作和自学任务，提供全方位的学习路径",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Key Features",
+      items: [
+        {
+          title: "教学策略可根据您的需求量身定制",
+          description: "",
+        },
+        {
+          title: "融合全球公认标准",
+          description: "",
+        },
+        {
+          title: "互动学习与实时指导",
+          description: "",
+        },
+        {
+          title: "实用且有效的沟通技能",
+          description: "",
+        },
+        {
+          title: "专注于职业发展",
+          description: "",
+        },
+        {
+          title: "专业师资力量",
+          description: "由经验丰富的英语外教团队授课，确保学员获得高质量、针对性的语言指导",
+        },
+        {
+          title: "互动讨论与角色扮演",
+          description: "通过小组互动和模拟实际场景，学员将体验不同角色，并在模拟中提高沟通技巧",
+        },
+        {
+          title: "文化敏感度训练",
+          description: "专门设计的课程内容帮助学员理解和应对不同文化背景下的患者需求和行为反应",
+        },
+        {
+          title: "个性化反馈与指导",
+          description: "学员将在每个关键阶段获得专属的个性化反馈和建议，以不断提升其语言和沟通技巧",
+        },
+        {
+          title: "在线资源支持",
+          description: "学员可随时访问丰富的在线学习资源，包括视频教程、医学案例和词汇练习，灵活安排学习进度",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 在不同医疗场景下自我介绍",
+          description: "1. 在不同医疗场景下自我介绍",
+        },
+        {
+          title: "2. 医患关系建立",
+          description: "2. 医患关系建立",
+        },
+        {
+          title: "3. 理解患者的观点",
+          description: "3. 理解患者的观点",
+        },
+        {
+          title: "4. 提供沟通结构",
+          description: "4. 提供沟通结构",
+        },
+        {
+          title: "5. 信息传递",
+          description: "5. 信息传递",
+        },
+        {
+          title: "6. 信息汇总",
+          description: "6. 信息汇总",
+        },
+        {
+          title: "7. 场景 1：解释治疗方案",
+          description: "7. 场景 1：解释治疗方案",
+        },
+        {
+          title: "8. 场景 2：讨论诊断",
+          description: "8. 场景 2：讨论诊断",
+        },
+        {
+          title: "9. 场景 3：处理具有挑战性的行为",
+          description: "9. 场景 3：处理具有挑战性的行为",
+        },
+        {
+          title: "10. 场景 4：解释病情",
+          description: "10. 场景 4：解释病情",
+        },
+        {
+          title: "11. 场景 5：讨论手术",
+          description: "11. 场景 5：讨论手术",
+        },
+        {
+          title: "12. 场景 6：谈论疼痛",
+          description: "12. 场景 6：谈论疼痛",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Pre-Departure Medical English\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/en/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/en/preparatory-medical-english.ts
@@ -1,0 +1,144 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "preparatory-medical-english",
+  category: "medical-english",
+  subcategory: "foundations",
+  title: "Preparatory Medical English Programme",
+  shortDescription: "A 12-lesson foundation programme for healthcare professionals preparing for advanced medical English training",
+  metaDescription: "Preparatory Medical English Programme - A 12-lesson foundation programme for healthcare professionals preparing for advanced medical English training",
+  duration: "12 lessons",
+  audience: ["Healthcare Professionals", "English Foundation Learners"],
+  featured: false,
+  order: 5,
+  status: "published",
+
+  hero: {
+    headline: "Preparatory Medical English Programme",
+    lede: "A 12-lesson foundation programme for healthcare professionals preparing for advanced medical English training",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/preparatory-medical-english.webp",
+    imageAlt: "Preparatory Medical English Programme - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "本课程为英语水平较为基础（CEFR A2–B1 级）的医疗从业者搭建桥梁，助其向高阶医疗英语课程 过渡。通过结构化模块，学员将在真实临床场景中强化语法、医学词汇及听力技能，重点培养日常医 疗任务中的实用沟通能力，为后续专业学习建立信心与基础。\n\nCEFR (Common European Framework of Reference for Languages，欧洲语言共同参考框架) 国际通用语言能力评估标准，分为 A1（初级）至 C2（精通）六个等级。本课程对应\"A2 可完成简 单问诊\"至\"B1 能处理常规医疗对话\"能力阶段。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "系统性学习语法应用自信",
+          description: "通过问诊句型、时态结构及情态动词专项训练，掌握查体记录（如\"患者主诉持续性胸痛 3 天\"）、病情解释（如\"药物需饭后服用以减轻胃刺激\"）等场景的精准表达",
+        },
+        {
+          title: "构建标准化医学词库",
+          description: "建立全面的医学词汇基础，涵盖解剖术语、诊断标准与操作规范，确保临床文档清晰无误",
+        },
+        {
+          title: "临床听力与应答策略升级",
+          description: "通过 15 种以上常见临床场景（如交班汇报、患者教育对话），提升主动倾听与结构化应答技巧",
+        },
+        {
+          title: "增强跨科室协作沟通能力",
+          description: "在多学科医疗环境中展现专业沟通自主性，为进阶课程（如医学写作）奠定衔接基础",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Key Features",
+      items: [
+        {
+          title: "基础场景实战闭环",
+          description: "",
+        },
+        {
+          title: "语法与句法强化体系",
+          description: "",
+        },
+        {
+          title: "医疗术语场景化学习",
+          description: "",
+        },
+        {
+          title: "动态听力实战训练",
+          description: "",
+        },
+        {
+          title: "高仿真情景学习工坊",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 身体与创伤",
+          description: "通过身体部位及创伤相关术语和提问结构，构建基础医学词汇。",
+        },
+        {
+          title: "2. 身体与创伤",
+          description: "通过描述创伤、听力练习和语法精炼，提升身体描述的沟通准确性。",
+        },
+        {
+          title: "3. 症状",
+          description: "通过症状识别、描述练习和细节导向的听力训练，提升症状辨识与解释清晰度。",
+        },
+        {
+          title: "4. 症状",
+          description: "通过语法训练（过去式 / 现在时）和情景化口语练习，提升症状时间线描述的流畅性。",
+        },
+        {
+          title: "5. 检查及诊断",
+          description: "掌握检查术语和报告语言，以有效讨论医学检测。",
+        },
+        {
+          title: "6. 检查及诊断",
+          description: "通过语法重点（将来时）和准确性训练，强化结果解释的清晰度。",
+        },
+        {
+          title: "7. 治疗与程序",
+          description: "开发逐步流程词汇，用于解释治疗方案。",
+        },
+        {
+          title: "8. 治疗与程序",
+          description: "通过流程术语和语法重点（情态动词），优化医疗指令传达。",
+        },
+        {
+          title: "9. 设施与设备",
+          description: "掌握医院环境和设备沟通的关键词汇。",
+        },
+        {
+          title: "10. 设施与设备",
+          description: "通过设备相关的口语任务和语法应用，提升职场沟通精确性。",
+        },
+        {
+          title: "11. 复习：创伤与症状",
+          description: "通过创伤和症状管理的综合听说练习，巩固核心技能。",
+        },
+        {
+          title: "12. 复习：检查与诊断",
+          description: "通过高阶实践强化诊断与治疗能力，为进阶医疗英语学习做准备。",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Preparatory Medical English Programme\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
@@ -1,0 +1,194 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-english-for-doctors",
+  category: "medical-english",
+  subcategory: "clinical",
+  title: "医生英语",
+  shortDescription: "医疗专业人员语言沟通能力提升课程",
+  metaDescription: "医生英语 - 医疗专业人员语言沟通能力提升课程",
+  duration: "12 周",
+  audience: ["医生", "医疗专业人士"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "医生英语",
+    lede: "医疗专业人员语言沟通能力提升课程",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-english-for-doctors.webp",
+    imageAlt: "医生英语 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "以职业英语考试（OET）为基础，课程重点关注真实医疗情境，培养医生自信沟通能力和跨文化意识， 助力提供优质医疗服务。参与者将学会与患者有效互动、与多学科团队协作、管理专业通信， 并对全球医学研究做出贡献。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "掌握医学术语：熟练运用专业医学词汇，确保精准的医患沟通",
+          description: "",
+        },
+        {
+          title: "提升临床互动：具备提问、描述、指导的能力，开展高效的医患交流",
+          description: "",
+        },
+        {
+          title: "改善患者咨询：掌握访谈技巧，倾听患者需求，提供专业医疗建议",
+          description: "",
+        },
+        {
+          title: "加强文档报告：准确撰写医学报告，规范记录患者信息",
+          description: "",
+        },
+        {
+          title: "连接全球医疗：参与国际研究合作，为医学发展贡献力量",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "教学方法",
+      items: [
+        {
+          title: "互动教学与合作学习",
+          description: "",
+        },
+        {
+          title: "角色扮演、模拟、案例分析",
+          description: "",
+        },
+        {
+          title: "OET 考试导向练习",
+          description: "",
+        },
+        {
+          title: "小组讨论、同行反馈",
+          description: "",
+        },
+        {
+          title: "多媒体辅助教学",
+          description: "",
+        },
+        {
+          title: "社区互动支持",
+          description: "",
+        },
+        {
+          title: "导师指导",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "核心特色",
+      items: [
+        {
+          title: "全面定制化学习路径",
+          description: "",
+        },
+        {
+          title: "融入国际标准",
+          description: "",
+        },
+        {
+          title: "互动支持式学习",
+          description: "",
+        },
+        {
+          title: "文化敏感沟通",
+          description: "",
+        },
+        {
+          title: "实用专业导向",
+          description: "",
+        },
+        {
+          title: "持续跟踪进步",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "基础知识",
+          description: "基础知识",
+        },
+        {
+          title: "医学与辅助医学人员与场所",
+          description: "医学与辅助医学人员与场所",
+        },
+        {
+          title: "教育与培训",
+          description: "教育与培训",
+        },
+        {
+          title: "系统、疾病与症状（20 个子模块）",
+          description: "系统、疾病与症状（20 个子模块）",
+        },
+        {
+          title: "检查",
+          description: "检查",
+        },
+        {
+          title: "治疗",
+          description: "治疗",
+        },
+        {
+          title: "预防",
+          description: "预防",
+        },
+        {
+          title: "流行病学",
+          description: "流行病学",
+        },
+        {
+          title: "伦理学",
+          description: "伦理学",
+        },
+        {
+          title: "研究",
+          description: "研究",
+        },
+        {
+          title: "采集病史",
+          description: "采集病史",
+        },
+        {
+          title: "检查（临床）",
+          description: "检查（临床）",
+        },
+        {
+          title: "解释",
+          description: "解释",
+        },
+        {
+          title: "展示",
+          description: "展示",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「医生英语」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
@@ -1,0 +1,186 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-english-for-nurses",
+  category: "medical-english",
+  subcategory: "clinical",
+  title: "护理英语课程",
+  shortDescription: "一个为医疗专业人员量身定制的高级实践导向 50 节课程，旨在提升其语言能力和沟通技巧",
+  metaDescription: "护理英语课程 - 一个为医疗专业人员量身定制的高级实践导向 50 节课程，旨在提升其语言能力和沟通技巧",
+  duration: "50 节课",
+  audience: ["护士", "护理专业人士"],
+  featured: false,
+  order: 30,
+  status: "published",
+
+  hero: {
+    headline: "护理英语课程",
+    lede: "一个为医疗专业人员量身定制的高级实践导向 50 节课程，旨在提升其语言能力和沟通技巧",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-english-for-nurses.webp",
+    imageAlt: "护理英语课程 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "护士医学英语课程是一门专为护士设计的专业课程，旨在提升其在英语医疗环境中有效进行患者护理 和协作所需的沟通技巧和医学词汇。该课程围绕职业英语测试（OET）结构，为护士提供日常与患者、 同事及其他医疗专业人士互动所需的实用语言技能。课程精心策划，帮助护士增强专业能力，自信应 对医疗场景，提升职业表现。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "医学术语发展：全面掌握医学术语及其在临床中的应用",
+          description: "",
+        },
+        {
+          title: "提升临床沟通技能：通过职业英语测试（OET）材料提高护理场景中的听、说、读、写能力",
+          description: "",
+        },
+        {
+          title: "改善患者沟通：在患者评估、健康检查和紧急情况下促进有效沟通",
+          description: "",
+        },
+        {
+          title: "增强患者护理中的能力与同理心：培养准确且富有同理心的患者教育和治疗信息传达能力",
+          description: "",
+        },
+        {
+          title: "强化文档与报告能力：掌握医疗环境中所需的高级英语结构，以实现清晰的文档与报告",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "教学方法",
+      items: [
+        {
+          title: "互动与协作学习",
+          description: "",
+        },
+        {
+          title: "角色扮演、模拟与案例分析",
+          description: "",
+        },
+        {
+          title: "基于 OET 的结构化练习",
+          description: "",
+        },
+        {
+          title: "小组讨论与互评",
+          description: "",
+        },
+        {
+          title: "多媒体资料",
+          description: "",
+        },
+        {
+          title: "社区支持",
+          description: "",
+        },
+        {
+          title: "辅导与指导",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "核心特色",
+      items: [
+        {
+          title: "全面且个性化的学习路径",
+          description: "",
+        },
+        {
+          title: "国际认可标准的整合",
+          description: "",
+        },
+        {
+          title: "互动学习与支持性环境",
+          description: "",
+        },
+        {
+          title: "文化敏感与有效沟通",
+          description: "",
+        },
+        {
+          title: "实用、相关且专业导向",
+          description: "",
+        },
+        {
+          title: "持续进步跟踪",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "基础知识",
+          description: "基础知识",
+        },
+        {
+          title: "医学与辅助医学人员与场所",
+          description: "医学与辅助医学人员与场所",
+        },
+        {
+          title: "教育与培训",
+          description: "教育与培训",
+        },
+        {
+          title: "系统、疾病与症状（20 个子模块）",
+          description: "系统、疾病与症状（20 个子模块）",
+        },
+        {
+          title: "检查",
+          description: "检查",
+        },
+        {
+          title: "治疗",
+          description: "治疗",
+        },
+        {
+          title: "预防",
+          description: "预防",
+        },
+        {
+          title: "流行病学",
+          description: "流行病学",
+        },
+        {
+          title: "伦理学",
+          description: "伦理学",
+        },
+        {
+          title: "采集病史",
+          description: "采集病史",
+        },
+        {
+          title: "检查（临床）",
+          description: "检查（临床）",
+        },
+        {
+          title: "解释",
+          description: "解释",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「护理英语课程」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
@@ -1,0 +1,160 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "pre-departure-medical-english",
+  category: "medical-english",
+  subcategory: "global-mobility",
+  title: "行前医学英语培训",
+  shortDescription: "为期 12 周的语言强化课程，专为即将赴海外进行临床实习的医疗专业人员设计",
+  metaDescription: "行前医学英语培训 - 为期 12 周的语言强化课程，专为即将赴海外进行临床实习的医疗专业人员设计",
+  duration: "12 周",
+  audience: ["即将出国医疗人士", "海外深造学员"],
+  featured: false,
+  order: 40,
+  status: "published",
+
+  hero: {
+    headline: "行前医学英语培训",
+    lede: "为期 12 周的语言强化课程，专为即将赴海外进行临床实习的医疗专业人员设计",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/pre-departure-medical-english.webp",
+    imageAlt: "行前医学英语培训 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "课程旨在帮助学员掌握在国际医疗环境中所需的沟通技巧和文化敏感度，提升他们在不同医疗场景中 的自信表现。通过实际操作与理论结合，学员将学会在多文化背景下高效地与患者、同事及其他医疗 团队成员进行交流。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "真实情境模拟",
+          description: "本课程将实际医疗场景引入课堂，确保学员可以身临其境地体验跨文化沟通的挑战和解决方案",
+        },
+        {
+          title: "以患者为中心的沟通框架",
+          description: "学员将学习并应用剑桥-卡尔加里指南，优化对患者咨询服务，确保信息清晰传达并展现同理心",
+        },
+        {
+          title: "多元化学习体验",
+          description: "课程结合互动讨论、实践操作和自学任务，提供全方位的学习路径",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "核心特色",
+      items: [
+        {
+          title: "教学策略可根据您的需求量身定制",
+          description: "",
+        },
+        {
+          title: "融合全球公认标准",
+          description: "",
+        },
+        {
+          title: "互动学习与实时指导",
+          description: "",
+        },
+        {
+          title: "实用且有效的沟通技能",
+          description: "",
+        },
+        {
+          title: "专注于职业发展",
+          description: "",
+        },
+        {
+          title: "专业师资力量",
+          description: "由经验丰富的英语外教团队授课，确保学员获得高质量、针对性的语言指导",
+        },
+        {
+          title: "互动讨论与角色扮演",
+          description: "通过小组互动和模拟实际场景，学员将体验不同角色，并在模拟中提高沟通技巧",
+        },
+        {
+          title: "文化敏感度训练",
+          description: "专门设计的课程内容帮助学员理解和应对不同文化背景下的患者需求和行为反应",
+        },
+        {
+          title: "个性化反馈与指导",
+          description: "学员将在每个关键阶段获得专属的个性化反馈和建议，以不断提升其语言和沟通技巧",
+        },
+        {
+          title: "在线资源支持",
+          description: "学员可随时访问丰富的在线学习资源，包括视频教程、医学案例和词汇练习，灵活安排学习进度",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 在不同医疗场景下自我介绍",
+          description: "1. 在不同医疗场景下自我介绍",
+        },
+        {
+          title: "2. 医患关系建立",
+          description: "2. 医患关系建立",
+        },
+        {
+          title: "3. 理解患者的观点",
+          description: "3. 理解患者的观点",
+        },
+        {
+          title: "4. 提供沟通结构",
+          description: "4. 提供沟通结构",
+        },
+        {
+          title: "5. 信息传递",
+          description: "5. 信息传递",
+        },
+        {
+          title: "6. 信息汇总",
+          description: "6. 信息汇总",
+        },
+        {
+          title: "7. 场景 1：解释治疗方案",
+          description: "7. 场景 1：解释治疗方案",
+        },
+        {
+          title: "8. 场景 2：讨论诊断",
+          description: "8. 场景 2：讨论诊断",
+        },
+        {
+          title: "9. 场景 3：处理具有挑战性的行为",
+          description: "9. 场景 3：处理具有挑战性的行为",
+        },
+        {
+          title: "10. 场景 4：解释病情",
+          description: "10. 场景 4：解释病情",
+        },
+        {
+          title: "11. 场景 5：讨论手术",
+          description: "11. 场景 5：讨论手术",
+        },
+        {
+          title: "12. 场景 6：谈论疼痛",
+          description: "12. 场景 6：谈论疼痛",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「行前医学英语培训」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
@@ -1,0 +1,144 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "preparatory-medical-english",
+  category: "medical-english",
+  subcategory: "foundations",
+  title: "预备通用英语课程",
+  shortDescription: "12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
+  metaDescription: "预备通用英语课程 - 12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
+  duration: "12 课时",
+  audience: ["医疗专业人士", "英语基础学员"],
+  featured: false,
+  order: 5,
+  status: "published",
+
+  hero: {
+    headline: "预备通用英语课程",
+    lede: "12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/preparatory-medical-english.webp",
+    imageAlt: "预备通用英语课程 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "本课程为英语水平较为基础（CEFR A2–B1 级）的医疗从业者搭建桥梁，助其向高阶医疗英语课程 过渡。通过结构化模块，学员将在真实临床场景中强化语法、医学词汇及听力技能，重点培养日常医 疗任务中的实用沟通能力，为后续专业学习建立信心与基础。\n\nCEFR (Common European Framework of Reference for Languages，欧洲语言共同参考框架) 国际通用语言能力评估标准，分为 A1（初级）至 C2（精通）六个等级。本课程对应\"A2 可完成简 单问诊\"至\"B1 能处理常规医疗对话\"能力阶段。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "系统性学习语法应用自信",
+          description: "通过问诊句型、时态结构及情态动词专项训练，掌握查体记录（如\"患者主诉持续性胸痛 3 天\"）、病情解释（如\"药物需饭后服用以减轻胃刺激\"）等场景的精准表达",
+        },
+        {
+          title: "构建标准化医学词库",
+          description: "建立全面的医学词汇基础，涵盖解剖术语、诊断标准与操作规范，确保临床文档清晰无误",
+        },
+        {
+          title: "临床听力与应答策略升级",
+          description: "通过 15 种以上常见临床场景（如交班汇报、患者教育对话），提升主动倾听与结构化应答技巧",
+        },
+        {
+          title: "增强跨科室协作沟通能力",
+          description: "在多学科医疗环境中展现专业沟通自主性，为进阶课程（如医学写作）奠定衔接基础",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "核心特色",
+      items: [
+        {
+          title: "基础场景实战闭环",
+          description: "",
+        },
+        {
+          title: "语法与句法强化体系",
+          description: "",
+        },
+        {
+          title: "医疗术语场景化学习",
+          description: "",
+        },
+        {
+          title: "动态听力实战训练",
+          description: "",
+        },
+        {
+          title: "高仿真情景学习工坊",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 身体与创伤",
+          description: "通过身体部位及创伤相关术语和提问结构，构建基础医学词汇。",
+        },
+        {
+          title: "2. 身体与创伤",
+          description: "通过描述创伤、听力练习和语法精炼，提升身体描述的沟通准确性。",
+        },
+        {
+          title: "3. 症状",
+          description: "通过症状识别、描述练习和细节导向的听力训练，提升症状辨识与解释清晰度。",
+        },
+        {
+          title: "4. 症状",
+          description: "通过语法训练（过去式 / 现在时）和情景化口语练习，提升症状时间线描述的流畅性。",
+        },
+        {
+          title: "5. 检查及诊断",
+          description: "掌握检查术语和报告语言，以有效讨论医学检测。",
+        },
+        {
+          title: "6. 检查及诊断",
+          description: "通过语法重点（将来时）和准确性训练，强化结果解释的清晰度。",
+        },
+        {
+          title: "7. 治疗与程序",
+          description: "开发逐步流程词汇，用于解释治疗方案。",
+        },
+        {
+          title: "8. 治疗与程序",
+          description: "通过流程术语和语法重点（情态动词），优化医疗指令传达。",
+        },
+        {
+          title: "9. 设施与设备",
+          description: "掌握医院环境和设备沟通的关键词汇。",
+        },
+        {
+          title: "10. 设施与设备",
+          description: "通过设备相关的口语任务和语法应用，提升职场沟通精确性。",
+        },
+        {
+          title: "11. 复习：创伤与症状",
+          description: "通过创伤和症状管理的综合听说练习，巩固核心技能。",
+        },
+        {
+          title: "12. 复习：检查与诊断",
+          description: "通过高阶实践强化诊断与治疗能力，为进阶医疗英语学习做准备。",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「预备通用英语课程」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/registry.ts
+++ b/content/programmes/registry.ts
@@ -21,11 +21,38 @@ const loaders: Record<string, LocaleLoaders> = {
     "zh-CN": () => import("./medical-english/zh-CN/oet-preparation"),
     en: () => import("./medical-english/en/oet-preparation"),
   },
-  // ── Add new courses here ──
-  // "medical-english/oet-intensive-bootcamp": {
-  //   "zh-CN": () => import("./medical-english/zh-CN/oet-intensive-bootcamp"),
-  //   en: () => import("./medical-english/en/oet-intensive-bootcamp"),
-  // },
+  "medical-english/preparatory-medical-english": {
+    "zh-CN": () => import("./medical-english/zh-CN/preparatory-medical-english"),
+    en: () => import("./medical-english/en/preparatory-medical-english"),
+  },
+  "medical-english/medical-english-for-doctors": {
+    "zh-CN": () => import("./medical-english/zh-CN/medical-english-for-doctors"),
+    en: () => import("./medical-english/en/medical-english-for-doctors"),
+  },
+  "medical-english/medical-english-for-nurses": {
+    "zh-CN": () => import("./medical-english/zh-CN/medical-english-for-nurses"),
+    en: () => import("./medical-english/en/medical-english-for-nurses"),
+  },
+  "medical-english/pre-departure-medical-english": {
+    "zh-CN": () => import("./medical-english/zh-CN/pre-departure-medical-english"),
+    en: () => import("./medical-english/en/pre-departure-medical-english"),
+  },
+  "research-academic/medical-research-essentials": {
+    "zh-CN": () => import("./research-academic/zh-CN/medical-research-essentials"),
+    en: () => import("./research-academic/en/medical-research-essentials"),
+  },
+  "research-academic/medical-writing-publication-bootcamp": {
+    "zh-CN": () => import("./research-academic/zh-CN/medical-writing-publication-bootcamp"),
+    en: () => import("./research-academic/en/medical-writing-publication-bootcamp"),
+  },
+  "humanities/medical-humanities-and-general-practice-literacy": {
+    "zh-CN": () => import("./humanities/zh-CN/medical-humanities-and-general-practice-literacy"),
+    en: () => import("./humanities/en/medical-humanities-and-general-practice-literacy"),
+  },
+  "humanities/medical-humanities-and-communication-skills": {
+    "zh-CN": () => import("./humanities/zh-CN/medical-humanities-and-communication-skills"),
+    en: () => import("./humanities/en/medical-humanities-and-communication-skills"),
+  },
 };
 
 /* ── Registry entries (lightweight, no full content) ── */
@@ -35,13 +62,92 @@ export const registry: ProgrammeRegistryEntry[] = [
     slug: "oet-preparation",
     category: "medical-english",
     subcategory: "oet",
-    title: "OET 备考课程", // display title is locale-dependent; this is the zh-CN default
+    title: "OET 备考课程",
     shortDescription: "提升您的医学英语能力，助力成功通过 OET 考试。",
     featured: true,
     order: 10,
     status: "published",
   },
-  // ── Add new entries here ──
+  {
+    slug: "preparatory-medical-english",
+    category: "medical-english",
+    subcategory: "foundations",
+    title: "预备通用英语课程",
+    shortDescription: "12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
+    featured: false,
+    order: 5,
+    status: "published",
+  },
+  {
+    slug: "medical-english-for-doctors",
+    category: "medical-english",
+    subcategory: "clinical",
+    title: "医生英语",
+    shortDescription: "医疗专业人员语言沟通能力提升课程",
+    featured: false,
+    order: 20,
+    status: "published",
+  },
+  {
+    slug: "medical-english-for-nurses",
+    category: "medical-english",
+    subcategory: "clinical",
+    title: "护士英语",
+    shortDescription: "护士专属医学英语沟通能力提升课程",
+    featured: false,
+    order: 30,
+    status: "published",
+  },
+  {
+    slug: "pre-departure-medical-english",
+    category: "medical-english",
+    subcategory: "global-mobility",
+    title: "出国前医学英语",
+    shortDescription: "12 周强化语言项目，专为即将海外临床实习的医疗专业人士打造",
+    featured: false,
+    order: 40,
+    status: "published",
+  },
+  {
+    slug: "medical-research-essentials",
+    category: "research-academic",
+    subcategory: "research-training",
+    title: "医学研究基础",
+    shortDescription: "6 周系统学习医学研究方法与循证医学（英语 B1+）",
+    featured: false,
+    order: 10,
+    status: "published",
+  },
+  {
+    slug: "medical-writing-publication-bootcamp",
+    category: "research-academic",
+    subcategory: "academic-writing",
+    title: "医学写作与发表集训营",
+    shortDescription: "12 小时集中训练 SCI 论文写作与国际发表技巧",
+    featured: false,
+    order: 20,
+    status: "published",
+  },
+  {
+    slug: "medical-humanities-and-general-practice-literacy",
+    category: "humanities",
+    subcategory: "medical-humanities",
+    title: "医学人文与全科素养",
+    shortDescription: "10 节课系统培养医学人文素养与全科执业能力",
+    featured: false,
+    order: 10,
+    status: "published",
+  },
+  {
+    slug: "medical-humanities-and-communication-skills",
+    category: "humanities",
+    subcategory: "medical-humanities",
+    title: "医学人文与沟通技能",
+    shortDescription: "6 节课提升医患沟通能力与人文关怀实践",
+    featured: false,
+    order: 20,
+    status: "published",
+  },
 ];
 
 /* ── Helpers ── */

--- a/content/programmes/research-academic/en/medical-research-essentials.ts
+++ b/content/programmes/research-academic/en/medical-research-essentials.ts
@@ -1,0 +1,128 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-research-essentials",
+  category: "research",
+  subcategory: "research-training",
+  title: "Medical Research Essentials",
+  shortDescription: "Research literacy programme for healthcare professionals",
+  metaDescription: "Medical Research Essentials - Research literacy programme for healthcare professionals",
+  duration: "6 weeks (English B1+)",
+  audience: ["Medical Researchers", "Clinicians", "Postgraduates"],
+  featured: false,
+  order: 10,
+  status: "published",
+
+  hero: {
+    headline: "Medical Research Essentials",
+    lede: "Research literacy programme for healthcare professionals",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-research-essentials.webp",
+    imageAlt: "Medical Research Essentials - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "本课程为医疗从业者量身定制，系统传授医学研究的核心方法论与实战技能，涵盖研究设计、伦理合规、 数据管理及国际化学术沟通。通过模块化学习，学员将掌握从选题设计到论文发表的完整科研链条， 为参与国际合作或独立研究项目奠定坚实基础。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "医学研究全流程解析",
+          description: "掌握基础研究、临床研究等类型特点，理解从立项到发表的完整阶段划分",
+        },
+        {
+          title: "研究问题构建与文献综述",
+          description: "精准定位研究空白，系统检索中英文权威论文数据库",
+        },
+        {
+          title: "研究方法设计实战",
+          description: "根据研究目标选择随机对照试验（RCT）、队列研究等设计，规避常见方法学误区",
+        },
+        {
+          title: "伦理与合规管理",
+          description: "熟悉知情同意书撰写、伦理委员会申报流程及数据隐私保护规范",
+        },
+        {
+          title: "数据分析与结果解读",
+          description: "学习数据处理与分析基础操作，掌握图表制作与统计学意义阐释",
+        },
+        {
+          title: "英文论文读写进阶",
+          description: "精研 IMRAD 结构，强化摘要写作与国际期刊常用表达",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Teaching Methods",
+      items: [
+        {
+          title: "国际师资团队",
+          description: "由医学英语专家、研究方法论学者及 SCI 期刊审稿人联合授课",
+        },
+        {
+          title: "真实案例库",
+          description: "解析医学顶刊论文的写作逻辑和实际案例分析",
+        },
+        {
+          title: "带教式训练",
+          description: "分步骤指导文献精读、数据描述与讨论部分撰写",
+        },
+        {
+          title: "语言强化包",
+          description: "提供医学高频词汇表、连接词库及常见语法错误避坑指南",
+        },
+        {
+          title: "结业考核",
+          description: "完成一份研究方案展示或论文摘要，获得专家认证证书",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 医学研究导论：从理论到实践",
+          description: "1. 医学研究导论：从理论到实践",
+        },
+        {
+          title: "2. 研究问题构建与文献综述实战",
+          description: "2. 研究问题构建与文献综述实战",
+        },
+        {
+          title: "3. 研究设计与方法学精要",
+          description: "3. 研究设计与方法学精要",
+        },
+        {
+          title: "4. 伦理合规与科研管理",
+          description: "4. 伦理合规与科研管理",
+        },
+        {
+          title: "5. 数据收集 & 分析全教程",
+          description: "5. 数据收集 & 分析全教程",
+        },
+        {
+          title: "6. 国际期刊论文读写精修",
+          description: "6. 国际期刊论文读写精修",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical Research Essentials\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
@@ -1,0 +1,128 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-writing-publication-bootcamp",
+  category: "research",
+  subcategory: "academic-writing",
+  title: "Medical Writing & Publication Bootcamp",
+  shortDescription: "Master the international medical publication pipeline",
+  metaDescription: "Medical Writing & Publication Bootcamp - Master the international medical publication pipeline",
+  duration: "12 hours",
+  audience: ["Medical Researchers", "Academic Writers"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "Medical Writing & Publication Bootcamp",
+    lede: "Master the international medical publication pipeline",
+    ctaLabel: "Get Started Today",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-writing-publication-bootcamp.webp",
+    imageAlt: "Medical Writing & Publication Bootcamp - Course hero",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "Course Overview",
+      body: "医学写作与发表强化训练营，致力于系统化提升国际医学论文写作与发表能力。",
+    },
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      items: [
+        {
+          title: "系统掌握国际医学出版全流程（SCI/SSCI/Medline 标准），包括论文评审机制与行业规范",
+          description: "",
+        },
+        {
+          title: "深入解析国际医学期刊文章的核心结构、写作惯例与文体特征，提升学术表达的精准度",
+          description: "",
+        },
+        {
+          title: "强化医学研究写作中的学术英语能力，攻克语法、术语与句式难点",
+          description: "",
+        },
+        {
+          title: "掌握数据可视化呈现、逻辑链构建及科学叙事技巧，打造高影响力的医学论文",
+          description: "",
+        },
+        {
+          title: "实战演练期刊筛选、稿件投递及审稿意见回复策略，全面提升发表成功率",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Key Features",
+      items: [
+        {
+          title: "系统性写作进阶框架",
+          description: "从选题设计到论文发表的全程方法论指导",
+        },
+        {
+          title: "医学学术英语精修",
+          description: "破解\"中式英语\"陷阱，学习高频学术表达与精准术语应用",
+        },
+        {
+          title: "期刊匹配精准导航",
+          description: "基于研究领域、影响力与审稿周期，瞄准合适期刊发表",
+        },
+        {
+          title: "智能工具赋能写作",
+          description: "实战演练 AI 工具辅助写作，提升语法校对、文献管理与效率",
+        },
+        {
+          title: "真实案例深度剖析",
+          description: "对比分析高分论文与典型拒稿案例，提炼可复制的成功要素",
+        },
+        {
+          title: "个性化专家反馈",
+          description: "针对学员初稿提供逐行批注与修改建议，加速论文优化进程",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "Curriculum",
+      items: [
+        {
+          title: "1. 中国医生国际发表困境解析",
+          description: "1. 中国医生国际发表困境解析",
+        },
+        {
+          title: "2. SCI 发表的核心逻辑与实战策略",
+          description: "2. SCI 发表的核心逻辑与实战策略",
+        },
+        {
+          title: "3. 医学论文解构与写作精要（IMRaD 框架）",
+          description: "3. 医学论文解构与写作精要（IMRaD 框架）",
+        },
+        {
+          title: "4. 学术英语写作体系精讲",
+          description: "4. 学术英语写作体系精讲",
+        },
+        {
+          title: "5. 投稿材料准备与审稿沟通实战",
+          description: "5. 投稿材料准备与审稿沟通实战",
+        },
+        {
+          title: "6. 案例解析与写作实战工作坊",
+          description: "6. 案例解析与写作实战工作坊",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "Ready to start \"Medical Writing & Publication Bootcamp\"?",
+    buttonLabel: "Get in Touch",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
+++ b/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
@@ -1,0 +1,128 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-research-essentials",
+  category: "research",
+  subcategory: "research-training",
+  title: "医学研究核心技能",
+  shortDescription: "医疗从业者科研素养提升课程",
+  metaDescription: "医学研究核心技能 - 医疗从业者科研素养提升课程",
+  duration: "6 周（英语 B1+）",
+  audience: ["医学研究人员", "临床医生", "研究生"],
+  featured: false,
+  order: 10,
+  status: "published",
+
+  hero: {
+    headline: "医学研究核心技能",
+    lede: "医疗从业者科研素养提升课程",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-research-essentials.webp",
+    imageAlt: "医学研究核心技能 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "本课程为医疗从业者量身定制，系统传授医学研究的核心方法论与实战技能，涵盖研究设计、伦理合规、 数据管理及国际化学术沟通。通过模块化学习，学员将掌握从选题设计到论文发表的完整科研链条， 为参与国际合作或独立研究项目奠定坚实基础。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "医学研究全流程解析",
+          description: "掌握基础研究、临床研究等类型特点，理解从立项到发表的完整阶段划分",
+        },
+        {
+          title: "研究问题构建与文献综述",
+          description: "精准定位研究空白，系统检索中英文权威论文数据库",
+        },
+        {
+          title: "研究方法设计实战",
+          description: "根据研究目标选择随机对照试验（RCT）、队列研究等设计，规避常见方法学误区",
+        },
+        {
+          title: "伦理与合规管理",
+          description: "熟悉知情同意书撰写、伦理委员会申报流程及数据隐私保护规范",
+        },
+        {
+          title: "数据分析与结果解读",
+          description: "学习数据处理与分析基础操作，掌握图表制作与统计学意义阐释",
+        },
+        {
+          title: "英文论文读写进阶",
+          description: "精研 IMRAD 结构，强化摘要写作与国际期刊常用表达",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "教学方法",
+      items: [
+        {
+          title: "国际师资团队",
+          description: "由医学英语专家、研究方法论学者及 SCI 期刊审稿人联合授课",
+        },
+        {
+          title: "真实案例库",
+          description: "解析医学顶刊论文的写作逻辑和实际案例分析",
+        },
+        {
+          title: "带教式训练",
+          description: "分步骤指导文献精读、数据描述与讨论部分撰写",
+        },
+        {
+          title: "语言强化包",
+          description: "提供医学高频词汇表、连接词库及常见语法错误避坑指南",
+        },
+        {
+          title: "结业考核",
+          description: "完成一份研究方案展示或论文摘要，获得专家认证证书",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 医学研究导论：从理论到实践",
+          description: "1. 医学研究导论：从理论到实践",
+        },
+        {
+          title: "2. 研究问题构建与文献综述实战",
+          description: "2. 研究问题构建与文献综述实战",
+        },
+        {
+          title: "3. 研究设计与方法学精要",
+          description: "3. 研究设计与方法学精要",
+        },
+        {
+          title: "4. 伦理合规与科研管理",
+          description: "4. 伦理合规与科研管理",
+        },
+        {
+          title: "5. 数据收集 & 分析全教程",
+          description: "5. 数据收集 & 分析全教程",
+        },
+        {
+          title: "6. 国际期刊论文读写精修",
+          description: "6. 国际期刊论文读写精修",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「医学研究核心技能」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
@@ -1,0 +1,128 @@
+import type { ProgrammeData } from "../../types";
+
+const data: ProgrammeData = {
+  slug: "medical-writing-publication-bootcamp",
+  category: "research",
+  subcategory: "academic-writing",
+  title: "医学写作与发表强化训练营",
+  shortDescription: "系统掌握国际医学出版全流程",
+  metaDescription: "医学写作与发表强化训练营 - 系统掌握国际医学出版全流程",
+  duration: "12 小时",
+  audience: ["医学研究人员", "学术写作者"],
+  featured: false,
+  order: 20,
+  status: "published",
+
+  hero: {
+    headline: "医学写作与发表强化训练营",
+    lede: "系统掌握国际医学出版全流程",
+    ctaLabel: "立即开始",
+    ctaHref: "/contact",
+    image: "/images/hero/programmes/medical-writing-publication-bootcamp.webp",
+    imageAlt: "医学写作与发表强化训练营 - 课程封面",
+  },
+
+  sections: [
+    {
+      type: "intro",
+      title: "课程概览",
+      body: "医学写作与发表强化训练营，致力于系统化提升国际医学论文写作与发表能力。",
+    },
+    {
+      type: "value-props",
+      title: "学习目标",
+      items: [
+        {
+          title: "系统掌握国际医学出版全流程（SCI/SSCI/Medline 标准），包括论文评审机制与行业规范",
+          description: "",
+        },
+        {
+          title: "深入解析国际医学期刊文章的核心结构、写作惯例与文体特征，提升学术表达的精准度",
+          description: "",
+        },
+        {
+          title: "强化医学研究写作中的学术英语能力，攻克语法、术语与句式难点",
+          description: "",
+        },
+        {
+          title: "掌握数据可视化呈现、逻辑链构建及科学叙事技巧，打造高影响力的医学论文",
+          description: "",
+        },
+        {
+          title: "实战演练期刊筛选、稿件投递及审稿意见回复策略，全面提升发表成功率",
+          description: "",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "核心特色",
+      items: [
+        {
+          title: "系统性写作进阶框架",
+          description: "从选题设计到论文发表的全程方法论指导",
+        },
+        {
+          title: "医学学术英语精修",
+          description: "破解\"中式英语\"陷阱，学习高频学术表达与精准术语应用",
+        },
+        {
+          title: "期刊匹配精准导航",
+          description: "基于研究领域、影响力与审稿周期，瞄准合适期刊发表",
+        },
+        {
+          title: "智能工具赋能写作",
+          description: "实战演练 AI 工具辅助写作，提升语法校对、文献管理与效率",
+        },
+        {
+          title: "真实案例深度剖析",
+          description: "对比分析高分论文与典型拒稿案例，提炼可复制的成功要素",
+        },
+        {
+          title: "个性化专家反馈",
+          description: "针对学员初稿提供逐行批注与修改建议，加速论文优化进程",
+        },
+      ],
+    },
+    {
+      type: "value-props",
+      title: "课程内容",
+      items: [
+        {
+          title: "1. 中国医生国际发表困境解析",
+          description: "1. 中国医生国际发表困境解析",
+        },
+        {
+          title: "2. SCI 发表的核心逻辑与实战策略",
+          description: "2. SCI 发表的核心逻辑与实战策略",
+        },
+        {
+          title: "3. 医学论文解构与写作精要（IMRaD 框架）",
+          description: "3. 医学论文解构与写作精要（IMRaD 框架）",
+        },
+        {
+          title: "4. 学术英语写作体系精讲",
+          description: "4. 学术英语写作体系精讲",
+        },
+        {
+          title: "5. 投稿材料准备与审稿沟通实战",
+          description: "5. 投稿材料准备与审稿沟通实战",
+        },
+        {
+          title: "6. 案例解析与写作实战工作坊",
+          description: "6. 案例解析与写作实战工作坊",
+        },
+      ],
+    },
+  ],
+
+  testimonials: [],
+
+  finalCta: {
+    headline: "准备好开始「医学写作与发表强化训练营」了吗？",
+    buttonLabel: "立即咨询",
+    buttonHref: "/contact",
+  },
+};
+
+export default data;

--- a/src/app/[locale]/programmes/humanities/page.tsx
+++ b/src/app/[locale]/programmes/humanities/page.tsx
@@ -10,7 +10,8 @@ const subcategories: SubCategory[] = [
     titleKey: "medicalHumanities",
     descKey: "medicalHumanitiesDesc",
     courses: [
-      { titleKey: "medicalHumanitiesProfessionals", status: "active" },
+      { titleKey: "medicalHumanitiesGeneralPractice", status: "active", slug: "medical-humanities-and-general-practice-literacy" },
+      { titleKey: "medicalHumanitiesCommunicationSkills", status: "active", slug: "medical-humanities-and-communication-skills" },
       { titleKey: "empathyPatientCommunication", status: "future" },
       { titleKey: "narrativeMedicine", status: "future" },
     ],

--- a/src/app/[locale]/programmes/medical-english/page.tsx
+++ b/src/app/[locale]/programmes/medical-english/page.tsx
@@ -10,7 +10,7 @@ const subcategories: SubCategory[] = [
     titleKey: "foundations",
     descKey: "foundationsDesc",
     courses: [
-      { titleKey: "preparatoryMedicalEnglish", status: "active" },
+      { titleKey: "preparatoryMedicalEnglish", status: "active", slug: "preparatory-medical-english" },
       { titleKey: "clinicalCommunicationFoundations", status: "future" },
       { titleKey: "generalEnglishHealthcare", status: "future" },
     ],
@@ -34,8 +34,8 @@ const subcategories: SubCategory[] = [
     descKey: "clinicalDesc",
     courses: [
       { titleKey: "workplaceMedicalEnglish", status: "active" },
-      { titleKey: "medicalEnglishDoctors", status: "active" },
-      { titleKey: "medicalEnglishNurses", status: "active" },
+      { titleKey: "medicalEnglishDoctors", status: "active", slug: "medical-english-for-doctors" },
+      { titleKey: "medicalEnglishNurses", status: "active", slug: "medical-english-for-nurses" },
       { titleKey: "clinicalConsultationEnglish", status: "future" },
       { titleKey: "wardHandoverCommunication", status: "future" },
     ],
@@ -46,7 +46,7 @@ const subcategories: SubCategory[] = [
     titleKey: "globalMobility",
     descKey: "globalMobilityDesc",
     courses: [
-      { titleKey: "preDepartureMedicalEnglish", status: "active" },
+      { titleKey: "preDepartureMedicalEnglish", status: "active", slug: "pre-departure-medical-english" },
       { titleKey: "ukHealthcareOrientation", status: "future" },
       { titleKey: "culturalCommunication", status: "future" },
       { titleKey: "internationalWorkplaceReadiness", status: "future" },

--- a/src/app/[locale]/programmes/research-academic/page.tsx
+++ b/src/app/[locale]/programmes/research-academic/page.tsx
@@ -10,7 +10,7 @@ const subcategories: SubCategory[] = [
     titleKey: "researchTraining",
     descKey: "researchTrainingDesc",
     courses: [
-      { titleKey: "medicalResearchEssentials", status: "active" },
+      { titleKey: "medicalResearchEssentials", status: "active", slug: "medical-research-essentials" },
       { titleKey: "researchMethodology", status: "future" },
       { titleKey: "evidenceBasedMedicine", status: "future" },
     ],
@@ -21,7 +21,7 @@ const subcategories: SubCategory[] = [
     titleKey: "academicWriting",
     descKey: "academicWritingDesc",
     courses: [
-      { titleKey: "medicalWritingBootcamp", status: "active" },
+      { titleKey: "medicalWritingBootcamp", status: "active", slug: "medical-writing-publication-bootcamp" },
       { titleKey: "sciWritingSupport", status: "future" },
       { titleKey: "academicPresentationSkills", status: "future" },
     ],

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -146,6 +146,12 @@
           "desc": "We ensure consistency and excellence in learning outcomes through a structured, professional, and scalable teaching framework, delivering a high-quality and reliable learning experience across all programmes."
         }
       ]
+    },
+    "humanities": {
+      "courses": {
+        "medicalHumanitiesGeneralPractice": "Medical Humanities & General Practice Literacy",
+        "medicalHumanitiesCommunicationSkills": "Medical Humanities & Communication Skills"
+      }
     }
   },
   "programmes": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -146,6 +146,12 @@
           "desc": "通过结构化、专业化且可复制的教学体系，确保课程交付的一致性与学习体验的高质量。"
         }
       ]
+    },
+    "humanities": {
+      "courses": {
+        "medicalHumanitiesGeneralPractice": "医学人文与全科素养",
+        "medicalHumanitiesCommunicationSkills": "医学人文与沟通技能"
+      }
     }
   },
   "programmes": {


### PR DESCRIPTION
## M6 — 8 门课按 OET 范例落地

章逊 2026-05-18 18:52 明确："8 门课今天必须落地"。

## 改动概览

### 新增 16 个 ts 数据文件（8 门 × 2 语言）

每个 ts 文件按 ProgrammeData 类型完整结构（hero + sections + testimonials + finalCta），内容从 `~/.openclaw/workspace/projects/mediversity-website/programmes-content-v2/*.mdx` 自动转换。

转换器：`/tmp/mdx-to-programme-ts.py`（Python 脚本，可复用 + 留档）

### registry.ts
注册 8 个新 loaders + entries：

| Slug | Category | Subcategory | Order |
|---|---|---|---|
| preparatory-medical-english | medical-english | foundations | 5 |
| oet-preparation | medical-english | oet | 10 (原有) |
| medical-english-for-doctors | medical-english | clinical | 20 |
| medical-english-for-nurses | medical-english | clinical | 30 |
| pre-departure-medical-english | medical-english | global-mobility | 40 |
| medical-research-essentials | research-academic | research-training | 10 |
| medical-writing-publication-bootcamp | research-academic | academic-writing | 20 |
| medical-humanities-and-general-practice-literacy | humanities | medical-humanities | 10 |
| medical-humanities-and-communication-skills | humanities | medical-humanities | 20 |

### Pillar page.tsx
给 active 课程加 slug 字段（让卡片可点击跳 detail）：
- medical-english: 4 个新 slug
- research-academic: 2 个新 slug
- humanities: 把占位 medicalHumanitiesProfessionals 拆成 2 门具体课程

### messages.programmesHub.humanities.courses
新增 2 个 titleKey（中英双语）：
- medicalHumanitiesGeneralPractice
- medicalHumanitiesCommunicationSkills

## 视觉密度提升预期 🎯

跟 Issue #60（章逊反馈"pillar 页很单薄"）相关：

| Pillar | 之前 active 课 | 现在 active 课 |
|---|---|---|
| medical-english | 1 (OET) | **5** ⬆️ +4 |
| research-academic | 0 | **2** ⬆️ +2 |
| humanities | 1 占位 | **2** ⬆️ +1 |

medical-english pillar 4 个 subcategory 都至少 1 门 active 课，不再单卡空荡。

## 英文版限制 ⚠️

mdx body 只有中文，**英文 ts 的 sections body 暂时是中文**：
- ✅ frontmatter 完全英文（title/tagline/duration/audience）
- ✅ hero headline / lede 英文
- ✅ shortDescription 英文（pillar/hub 卡片用这个）
- ✅ finalCta 英文
- ⚠️ sections body（detail page 详细内容）是中文

后续 Moss/章逊 安排英文翻译时只需更新 16 个 ts 文件的 sections 字段，schema 已就绪。

## 测试

- TypeScript 检查通过 ✅
- JSON 语法 ✅
- 待 staging redeploy 验证：
  - 中文 pillar 页课程卡数量从 1 → 5 (medical-english) / 2 (research) / 2 (humanities)
  - 点击卡片进 detail page 正常渲染
  - 中英文切换 OK
  - SSG 静态生成新增 8 × 2 = 16 个 detail page 路径

## 配合 Issue #60

本 PR 解决"内容稀缺导致空荡"问题。视觉密度的另一半（卡片样式/留白/布局节奏）等 @theathondmanus 在 Issue #60 处理。
