### PR TITLE
fix(footer): 中文版 footer 改成公司全称'上海千蓦信息咨询有限公司'

### DIFF
--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -398,7 +398,7 @@
     "sectionSupport": "支持",
     "privacyPolicy": "隐私政策",
     "termsOfService": "服务条款",
-    "accredited": "UK Medical Education Provider",
+    "accredited": "上海千蓦信息咨询有限公司",
     "icp": "沪ICP备2025138775号-2",
     "copyright": "© 2026 Mediversity Global. All rights reserved."
   }


### PR DESCRIPTION
## 章逊反馈

中文版 footer 上'UK Medical Education Provider'+'沪ICP备2025138775号-2'放一起不协调，应该用公司全称。

## 改动

- `src/messages/zh-CN.json`: footer.accredited 'UK Medical Education Provider' → '上海千蓦信息咨询有限公司'
- 英文版 footer.accredited 保留 'UK Medical Education Provider'（英文站描述合适）
- ICP 号 '沪ICP备2025138775号-2' 已经是这家公司的，跟备案主体一致

## 验证清单

- [ ] /  (zh) footer 显示 '上海千蓦信息咨询有限公司'
- [ ] /en footer 仍显示 'UK Medical Education Provider'
- [ ] /en/about footer 仍显示 'UK Medical Education Provider'