### PR TITLE
fix(i18n): humanities 2 个新 titleKey namespace 错位修复（PR #61 bug 跟修）

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -148,10 +148,7 @@
       ]
     },
     "humanities": {
-      "courses": {
-        "medicalHumanitiesGeneralPractice": "Medical Humanities & General Practice Literacy",
-        "medicalHumanitiesCommunicationSkills": "Medical Humanities & Communication Skills"
-      }
+      "courses": {}
     }
   },
   "programmes": {
@@ -272,7 +269,9 @@
         "narrativeMedicine": "Narrative Medicine",
         "healthcareLeadership": "Healthcare Leadership",
         "crossCulturalCommunication": "Cross-cultural Communication",
-        "reflectivePractice": "Reflective Practice"
+        "reflectivePractice": "Reflective Practice",
+        "medicalHumanitiesGeneralPractice": "Medical Humanities & General Practice Literacy",
+        "medicalHumanitiesCommunicationSkills": "Medical Humanities & Communication Skills"
       }
     }
   },

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -148,10 +148,7 @@
       ]
     },
     "humanities": {
-      "courses": {
-        "medicalHumanitiesGeneralPractice": "医学人文与全科素养",
-        "medicalHumanitiesCommunicationSkills": "医学人文与沟通技能"
-      }
+      "courses": {}
     }
   },
   "programmes": {
@@ -272,7 +269,9 @@
         "narrativeMedicine": "叙事医学",
         "healthcareLeadership": "医疗领导力",
         "crossCulturalCommunication": "跨文化沟通",
-        "reflectivePractice": "反思性实践"
+        "reflectivePractice": "反思性实践",
+        "medicalHumanitiesGeneralPractice": "医学人文与全科素养",
+        "medicalHumanitiesCommunicationSkills": "医学人文与沟通技能"
       }
     }
   },


### PR DESCRIPTION
PR #61 把 medicalHumanitiesGeneralPractice + medicalHumanitiesCommunicationSkills 错加到 programmesHub.humanities.courses，但 PillarLandingPage 用的是 programmes.humanities.courses namespace。导致章逊看到 humanities pillar 页两个新卡片显示原始 key 字符串。

把 2 个 titleKey 移到正确位置即可。