### PR TITLE
feat(programmes): 按板块共享 hero 图（不再每门课一张）

### DIFF
--- a/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Empathy-driven care — core skills for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-humanities-and-communication-skills.webp",
-    imageAlt: "Medical Humanities and Communication Skills - Course hero",
+    image: "/images/hero/humanities.webp",
+    imageAlt: "Medical humanities and professional development",
   },
 
   sections: [

--- a/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Reading disease with expertise, delivering care through dialogue",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-humanities-and-general-practice-literacy.webp",
-    imageAlt: "Medical Humanities and General Practice Literacy - Course hero",
+    image: "/images/hero/humanities.webp",
+    imageAlt: "Medical humanities and professional development",
   },
 
   sections: [

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "提升共情照护：赋能医疗从业者的核心技能",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-humanities-and-communication-skills.webp",
-    imageAlt: "医学人文与沟通技能 - 课程封面",
+    image: "/images/hero/humanities.webp",
+    imageAlt: "医学人文与职业发展",
   },
 
   sections: [

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "用专业解读疾病，用对话传递关怀",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-humanities-and-general-practice-literacy.webp",
-    imageAlt: "医学人文与全科医学素养 - 课程封面",
+    image: "/images/hero/humanities.webp",
+    imageAlt: "医学人文与职业发展",
   },
 
   sections: [

--- a/content/programmes/medical-english/en/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/en/medical-english-for-doctors.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Language and Communication Skills Programme for Healthcare Professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-english-for-doctors.webp",
-    imageAlt: "Medical English for Doctors - Course hero",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "Medical English & Clinical Communication training",
   },
 
   sections: [

--- a/content/programmes/medical-english/en/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/en/medical-english-for-nurses.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "An advanced, practice-oriented 50-lesson programme tailored for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-english-for-nurses.webp",
-    imageAlt: "Medical English for Nurses - Course hero",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "Medical English & Clinical Communication training",
   },
 
   sections: [

--- a/content/programmes/medical-english/en/oet-preparation.ts
+++ b/content/programmes/medical-english/en/oet-preparation.ts
@@ -20,8 +20,8 @@ const data: ProgrammeData = {
     lede: "Boost your medical English skills and help you achieve success in the OET exam.",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/oet-preparation.webp",
-    imageAlt: "OET study desk with medical textbooks and world map showing UK, Australia, New Zealand, Ireland",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "Medical English & Clinical Communication training",
   },
 
   sections: [

--- a/content/programmes/medical-english/en/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/en/pre-departure-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "A 12-week intensive language programme for healthcare professionals preparing for overseas clinical placement",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/pre-departure-medical-english.webp",
-    imageAlt: "Pre-Departure Medical English - Course hero",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "Medical English & Clinical Communication training",
   },
 
   sections: [

--- a/content/programmes/medical-english/en/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/en/preparatory-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "A 12-lesson foundation programme for healthcare professionals preparing for advanced medical English training",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/preparatory-medical-english.webp",
-    imageAlt: "Preparatory Medical English Programme - Course hero",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "Medical English & Clinical Communication training",
   },
 
   sections: [

--- a/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "医疗专业人员语言沟通能力提升课程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-english-for-doctors.webp",
-    imageAlt: "医生英语 - 课程封面",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "医学英语与沟通能力培训",
   },
 
   sections: [

--- a/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "一个为医疗专业人员量身定制的高级实践导向 50 节课程，旨在提升其语言能力和沟通技巧",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-english-for-nurses.webp",
-    imageAlt: "护理英语课程 - 课程封面",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "医学英语与沟通能力培训",
   },
 
   sections: [

--- a/content/programmes/medical-english/zh-CN/oet-preparation.ts
+++ b/content/programmes/medical-english/zh-CN/oet-preparation.ts
@@ -20,8 +20,8 @@ const data: ProgrammeData = {
     lede: "提升您的医学英语能力，助力成功通过 OET 考试。",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/oet-preparation.webp",
-    imageAlt: "OET study desk with medical textbooks and world map showing UK, Australia, New Zealand, Ireland",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "医学英语与沟通能力培训",
   },
 
   sections: [

--- a/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "为期 12 周的语言强化课程，专为即将赴海外进行临床实习的医疗专业人员设计",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/pre-departure-medical-english.webp",
-    imageAlt: "行前医学英语培训 - 课程封面",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "医学英语与沟通能力培训",
   },
 
   sections: [

--- a/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/preparatory-medical-english.webp",
-    imageAlt: "预备通用英语课程 - 课程封面",
+    image: "/images/hero/medical-english.webp",
+    imageAlt: "医学英语与沟通能力培训",
   },
 
   sections: [

--- a/content/programmes/research-academic/en/medical-research-essentials.ts
+++ b/content/programmes/research-academic/en/medical-research-essentials.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Research literacy programme for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-research-essentials.webp",
-    imageAlt: "Medical Research Essentials - Course hero",
+    image: "/images/hero/research.webp",
+    imageAlt: "Medical research and academic development",
   },
 
   sections: [

--- a/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Master the international medical publication pipeline",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-writing-publication-bootcamp.webp",
-    imageAlt: "Medical Writing & Publication Bootcamp - Course hero",
+    image: "/images/hero/research.webp",
+    imageAlt: "Medical research and academic development",
   },
 
   sections: [

--- a/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
+++ b/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "医疗从业者科研素养提升课程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-research-essentials.webp",
-    imageAlt: "医学研究核心技能 - 课程封面",
+    image: "/images/hero/research.webp",
+    imageAlt: "医学研究与学术发展",
   },
 
   sections: [

--- a/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "系统掌握国际医学出版全流程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/programmes/medical-writing-publication-bootcamp.webp",
-    imageAlt: "医学写作与发表强化训练营 - 课程封面",
+    image: "/images/hero/research.webp",
+    imageAlt: "医学研究与学术发展",
   },
 
   sections: [


### PR DESCRIPTION
章逊：四大培训板块中每一个板块下的课程共享同一个 Hero 图片。

## 改动 18 个 ts 文件
- medical-english 板块（5 门）→ /images/hero/medical-english.webp
- research-academic 板块（2 门）→ /images/hero/research.webp
- humanities 板块（2 门）→ /images/hero/humanities.webp

imageAlt 按板块统一描述（中英双语）。

@theathondmanus 后续可基于这 4 张板块 hero 图重点打磨，工作量从 9 张减到 4 张。