### PR TITLE
feat(home): case study carousel + bookshelf-style featured courses (Issue #81)

### DIFF
--- a/src/components/home/CaseStudyHighlight.tsx
+++ b/src/components/home/CaseStudyHighlight.tsx
@@ -4,7 +4,15 @@ import { Link } from "@/i18n/navigation";
 import { useLocale } from "next-intl";
 import { motion } from "framer-motion";
 import Image from "next/image";
-import { ArrowRight, TrendingUp, Users, Clock, Award } from "lucide-react";
+import { ArrowRight, TrendingUp, Users, Clock, Award, MapPin } from "lucide-react";
+import Autoplay from "embla-carousel-autoplay";
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+} from "@/components/ui/carousel";
 
 /* ── Animation variants ── */
 const fadeInUp = {
@@ -12,68 +20,128 @@ const fadeInUp = {
   visible: { opacity: 1, y: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] as const } },
 };
 
-const fadeInLeft = {
-  hidden: { opacity: 0, x: -30 },
-  visible: { opacity: 1, x: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] as const } },
-};
+/* ── Case study data (array-driven for future expansion) ── */
+interface CaseMetric {
+  icon: typeof TrendingUp;
+  value: string;
+  label: string;
+  subtext?: string;
+}
 
-const fadeInRight = {
-  hidden: { opacity: 0, x: 30 },
-  visible: { opacity: 1, x: 0, transition: { duration: 0.6, ease: [0.22, 1, 0.36, 1] as const } },
-};
+interface CaseStudy {
+  image: string;
+  imageAlt: string;
+  eyebrow: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  metrics: CaseMetric[];
+  quote: string;
+  quoteAuthor: string;
+  cta: string;
+  ctaLink: string;
+  location?: string;
+}
 
-const countUp = {
-  hidden: { opacity: 0, scale: 0.8 },
-  visible: { opacity: 1, scale: 1, transition: { duration: 0.5, ease: [0.22, 1, 0.36, 1] as const } },
-};
-
-/* ── Content data ── */
-const CONTENT = {
-  "zh-CN": {
-    eyebrow: "成功案例",
-    title: "12 周训练，84% 能力提升",
-    subtitle: "妇幼专科医院国际医疗沟通能力建设项目",
-    description:
-      "某妇幼专科医院通过 Mediversity Global 为期 12 周的定制化医学沟通培训，医护团队临床英语能力实现跨越式提升，为国际化服务拓展奠定坚实基础。",
-    metrics: [
-      { icon: TrendingUp, value: "84%", label: "能力提升幅度" },
-      { icon: Award, value: "72.5", label: "结业平均分", subtext: "（入学 39.4）" },
-      { icon: Clock, value: "12", label: "周定制训练" },
-      { icon: Users, value: "100%", label: "学员完成率" },
-    ],
-    quote: "以前总担心说错，现在可以更自信地与患者沟通，老师的反馈非常有帮助。",
-    quoteAuthor: "生殖医学科医生",
-    cta: "阅读完整案例",
-  },
-  en: {
-    eyebrow: "Case Study",
-    title: "12 Weeks, 84% Improvement",
-    subtitle: "Maternity Hospital International Medical Communication Programme",
-    description:
-      "A leading maternity hospital achieved transformative improvement in clinical English communication through Mediversity Global's 12-week customised training programme, establishing a solid foundation for international service expansion.",
-    metrics: [
-      { icon: TrendingUp, value: "84%", label: "Improvement" },
-      { icon: Award, value: "72.5", label: "Final Score", subtext: "(from 39.4)" },
-      { icon: Clock, value: "12", label: "Weeks" },
-      { icon: Users, value: "100%", label: "Completion Rate" },
-    ],
-    quote: "I used to worry about making mistakes. Now I can communicate with patients more confidently.",
-    quoteAuthor: "Reproductive Medicine Specialist",
-    cta: "Read Full Case Study",
-  },
+const CASES: Record<string, CaseStudy[]> = {
+  "zh-CN": [
+    {
+      image: "/images/cases/maternity-hospital-english.jpg",
+      imageAlt: "妇幼医院医学英语培训现场",
+      eyebrow: "成功案例",
+      title: "12 周训练，84% 能力提升",
+      subtitle: "妇幼专科医院国际医疗沟通能力建设项目",
+      description:
+        "某妇幼专科医院通过 Mediversity Global 为期 12 周的定制化医学沟通培训，医护团队临床英语能力实现跨越式提升，为国际化服务拓展奠定坚实基础。",
+      metrics: [
+        { icon: TrendingUp, value: "84%", label: "能力提升幅度" },
+        { icon: Award, value: "72.5", label: "结业平均分", subtext: "（入学 39.4）" },
+        { icon: Clock, value: "12", label: "周定制训练" },
+        { icon: Users, value: "100%", label: "学员完成率" },
+      ],
+      quote: "以前总担心说错，现在可以更自信地与患者沟通，老师的反馈非常有帮助。",
+      quoteAuthor: "生殖医学科医生",
+      cta: "阅读完整案例",
+      ctaLink: "/insights",
+    },
+    {
+      image: "/images/cases/indonesia-tcm-rehab.jpg",
+      imageAlt: "印尼患者在康复诊所接受中医针灸治疗",
+      eyebrow: "服务案例",
+      title: "跨境康复，本地化落地",
+      subtitle: "印尼患者 · 血栓术后中医康复导航",
+      location: "东南亚 · 印尼",
+      description:
+        "一位印尼患者在血栓切除术后面临肢体恢复缓慢的困境。我们以「先评估、再匹配」为核心，对接当地合法执业中医专家，设计多阶段康复路径，实现稳定、本地化、可持续的康复支持。",
+      metrics: [
+        { icon: MapPin, value: "4", label: "阶段康复路径" },
+        { icon: Users, value: "1v1", label: "专家匹配" },
+        { icon: Clock, value: "持续", label: "长期跟进" },
+        { icon: Award, value: "0", label: "次跨境奔波" },
+      ],
+      quote: "频繁跨境奔波并不是答案——稳定、本地化、可持续的康复支持，才是患者真正需要的。",
+      quoteAuthor: "Mediversity 导航团队",
+      cta: "了解医疗导航",
+      ctaLink: "/medical-navigator",
+    },
+  ],
+  en: [
+    {
+      image: "/images/cases/maternity-hospital-english.jpg",
+      imageAlt: "Medical communication training session",
+      eyebrow: "Case Study",
+      title: "12 Weeks, 84% Improvement",
+      subtitle: "Maternity Hospital International Medical Communication Programme",
+      description:
+        "A leading maternity hospital achieved transformative improvement in clinical English communication through Mediversity Global's 12-week customised training programme, establishing a solid foundation for international service expansion.",
+      metrics: [
+        { icon: TrendingUp, value: "84%", label: "Improvement" },
+        { icon: Award, value: "72.5", label: "Final Score", subtext: "(from 39.4)" },
+        { icon: Clock, value: "12", label: "Weeks" },
+        { icon: Users, value: "100%", label: "Completion Rate" },
+      ],
+      quote: "I used to worry about making mistakes. Now I can communicate with patients more confidently.",
+      quoteAuthor: "Reproductive Medicine Specialist",
+      cta: "Read Full Case Study",
+      ctaLink: "/insights",
+    },
+    {
+      image: "/images/cases/indonesia-tcm-rehab.jpg",
+      imageAlt: "Indonesian patient receiving TCM acupuncture treatment",
+      eyebrow: "Service Case",
+      title: "Cross-border Recovery, Localised Care",
+      subtitle: "Indonesian Patient · Post-thrombectomy TCM Rehabilitation",
+      location: "Southeast Asia · Indonesia",
+      description:
+        "An Indonesian patient facing slow recovery after thrombectomy received a multi-stage rehabilitation pathway designed around local feasibility, continuity of care, and long-term sustainability — matched with locally licensed TCM specialists.",
+      metrics: [
+        { icon: MapPin, value: "4", label: "Stage Pathway" },
+        { icon: Users, value: "1v1", label: "Expert Match" },
+        { icon: Clock, value: "Ongoing", label: "Follow-up" },
+        { icon: Award, value: "0", label: "Border Crossings" },
+      ],
+      quote: "Frequent international travel wasn't the answer — stable, local, sustainable rehabilitation support was what the patient truly needed.",
+      quoteAuthor: "Mediversity Navigation Team",
+      cta: "Learn About Medical Navigator",
+      ctaLink: "/medical-navigator",
+    },
+  ],
 };
 
 export default function CaseStudyHighlight() {
   const locale = useLocale() as "zh-CN" | "en";
-  const content = CONTENT[locale] || CONTENT["zh-CN"];
+  const cases = CASES[locale] || CASES["zh-CN"];
 
   return (
     <section className="relative py-20 md:py-28 overflow-hidden bg-white">
       {/* Subtle background pattern */}
-      <div className="absolute inset-0 opacity-[0.015]" style={{
-        backgroundImage: `radial-gradient(circle at 1px 1px, #00438A 1px, transparent 0)`,
-        backgroundSize: "32px 32px",
-      }} />
+      <div
+        className="absolute inset-0 opacity-[0.015]"
+        style={{
+          backgroundImage: `radial-gradient(circle at 1px 1px, #00438A 1px, transparent 0)`,
+          backgroundSize: "32px 32px",
+        }}
+      />
 
       <div className="container relative z-10">
         {/* Section header */}
@@ -82,93 +150,110 @@ export default function CaseStudyHighlight() {
           whileInView="visible"
           viewport={{ once: true, margin: "-80px" }}
           variants={fadeInUp}
-          className="text-center mb-16"
+          className="text-center mb-14"
         >
-          <p className="eyebrow">{content.eyebrow}</p>
-          <h2 className="font-display text-3xl md:text-4xl font-bold text-[#0A1628] mb-3">
-            {content.title}
+          <p className="eyebrow">{locale === "zh-CN" ? "成功案例" : "Case Studies"}</p>
+          <h2 className="font-display text-3xl md:text-4xl font-bold text-[#0A1628]">
+            {locale === "zh-CN" ? "真实成果，数据说话" : "Real Results, Data-Driven"}
           </h2>
-          <p className="text-lg text-[#3C3A47]">{content.subtitle}</p>
         </motion.div>
 
-        {/* Main content: image + data */}
-        <motion.div
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, margin: "-60px" }}
-          className="flex flex-col lg:flex-row items-stretch gap-10 lg:gap-14"
-        >
-          {/* Left: Image + quote overlay */}
-          <motion.div variants={fadeInLeft} className="w-full lg:w-5/12">
-            <div className="relative h-full min-h-[360px] rounded-2xl overflow-hidden shadow-xl group">
-              <Image
-                src="/images/cases/maternity-hospital-english.jpg"
-                alt="Medical communication training session"
-                fill
-                className="object-cover transition-transform duration-700 group-hover:scale-[1.02]"
-                sizes="(max-width: 1024px) 100vw, 42vw"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-[#0A1628]/80 via-[#0A1628]/20 to-transparent" />
-
-              {/* Quote overlay at bottom */}
-              <div className="absolute bottom-0 left-0 right-0 p-6 md:p-8">
-                <p className="text-white/90 text-sm md:text-base italic leading-relaxed mb-2">
-                  &ldquo;{content.quote}&rdquo;
-                </p>
-                <p className="text-white/60 text-xs">
-                  — {content.quoteAuthor}
-                </p>
-              </div>
-            </div>
-          </motion.div>
-
-          {/* Right: Metrics + description */}
-          <motion.div variants={fadeInRight} className="w-full lg:w-7/12 flex flex-col justify-center">
-            <p className="text-[#3C3A47] leading-relaxed text-base md:text-lg mb-8">
-              {content.description}
-            </p>
-
-            {/* Metrics grid */}
-            <motion.div
-              initial="hidden"
-              whileInView="visible"
-              viewport={{ once: true }}
-              className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-8"
-            >
-              {content.metrics.map((metric, i) => {
-                const Icon = metric.icon;
-                return (
-                  <motion.div
-                    key={i}
-                    variants={countUp}
-                    transition={{ delay: i * 0.1 }}
-                    className="relative bg-gradient-to-br from-[#F8F9FC] to-[#EEF1F8] rounded-xl p-5 text-center border border-[#E3E5EC]/60 hover:shadow-md transition-shadow"
-                  >
-                    <div className="w-9 h-9 rounded-lg bg-[#00438A]/10 flex items-center justify-center mx-auto mb-3">
-                      <Icon className="w-4.5 h-4.5 text-[#00438A]" />
+        {/* Carousel of case study cards */}
+        <div className="max-w-6xl mx-auto px-4 md:px-12">
+          <Carousel
+            opts={{ align: "start", loop: true }}
+            plugins={[
+              Autoplay({ delay: 7000, stopOnInteraction: true, stopOnMouseEnter: true }),
+            ]}
+          >
+            <CarouselContent className="-ml-4">
+              {cases.map((caseItem, caseIdx) => (
+                <CarouselItem key={caseIdx} className="pl-4 basis-full">
+                  {/* Single large card */}
+                  <div className="flex flex-col lg:flex-row items-stretch gap-8 lg:gap-12 bg-gradient-to-br from-[#F8F9FC] to-white rounded-2xl border border-[#E3E5EC]/60 shadow-lg overflow-hidden">
+                    {/* Left: Image + quote overlay */}
+                    <div className="w-full lg:w-5/12 relative min-h-[320px] lg:min-h-[420px]">
+                      <Image
+                        src={caseItem.image}
+                        alt={caseItem.imageAlt}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 1024px) 100vw, 42vw"
+                      />
+                      <div className="absolute inset-0 bg-gradient-to-t from-[#0A1628]/80 via-[#0A1628]/20 to-transparent" />
+                      {/* Quote overlay */}
+                      <div className="absolute bottom-0 left-0 right-0 p-6 md:p-8">
+                        <p className="text-white/90 text-sm md:text-base italic leading-relaxed mb-2">
+                          &ldquo;{caseItem.quote}&rdquo;
+                        </p>
+                        <p className="text-white/60 text-xs">— {caseItem.quoteAuthor}</p>
+                      </div>
                     </div>
-                    <p className="text-2xl md:text-3xl font-bold text-[#00438A] mb-1">
-                      {metric.value}
-                    </p>
-                    <p className="text-xs text-[#3C3A47] font-medium">{metric.label}</p>
-                    {metric.subtext && (
-                      <p className="text-[10px] text-[#8A889A] mt-0.5">{metric.subtext}</p>
-                    )}
-                  </motion.div>
-                );
-              })}
-            </motion.div>
 
-            {/* CTA */}
-            <Link
-              href="/insights"
-              className="inline-flex items-center gap-2 text-[#00438A] font-semibold hover:text-[#003066] transition-colors no-underline group/link self-start"
-            >
-              {content.cta}
-              <ArrowRight className="w-4 h-4 transition-transform group-hover/link:translate-x-1" />
-            </Link>
-          </motion.div>
-        </motion.div>
+                    {/* Right: Content + metrics */}
+                    <div className="w-full lg:w-7/12 flex flex-col justify-center p-6 md:p-8 lg:py-10 lg:pr-10 lg:pl-0">
+                      <div className="flex items-center gap-3 mb-3">
+                        <span className="text-xs font-semibold uppercase tracking-wider text-[#C4922A]">
+                          {caseItem.eyebrow}
+                        </span>
+                        {caseItem.location && (
+                          <span className="text-xs text-[#8A889A] flex items-center gap-1">
+                            <MapPin className="w-3 h-3" />
+                            {caseItem.location}
+                          </span>
+                        )}
+                      </div>
+                      <h3 className="font-display text-2xl md:text-3xl font-bold text-[#0A1628] mb-2">
+                        {caseItem.title}
+                      </h3>
+                      <p className="text-base text-[#3C3A47] mb-2 font-medium">
+                        {caseItem.subtitle}
+                      </p>
+                      <p className="text-sm md:text-base text-[#3C3A47] leading-relaxed mb-6">
+                        {caseItem.description}
+                      </p>
+
+                      {/* Metrics */}
+                      <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
+                        {caseItem.metrics.map((metric, i) => {
+                          const Icon = metric.icon;
+                          return (
+                            <div
+                              key={i}
+                              className="bg-white rounded-xl p-4 text-center border border-[#E3E5EC]/60 shadow-sm"
+                            >
+                              <div className="w-8 h-8 rounded-lg bg-[#00438A]/8 flex items-center justify-center mx-auto mb-2">
+                                <Icon className="w-4 h-4 text-[#00438A]" />
+                              </div>
+                              <p className="text-xl md:text-2xl font-bold text-[#00438A] mb-0.5">
+                                {metric.value}
+                              </p>
+                              <p className="text-[11px] text-[#3C3A47] font-medium">{metric.label}</p>
+                              {metric.subtext && (
+                                <p className="text-[10px] text-[#8A889A]">{metric.subtext}</p>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
+
+                      {/* CTA */}
+                      <Link
+                        href={caseItem.ctaLink as never}
+                        className="inline-flex items-center gap-2 text-[#00438A] font-semibold hover:text-[#003066] transition-colors no-underline group/link self-start"
+                      >
+                        {caseItem.cta}
+                        <ArrowRight className="w-4 h-4 transition-transform group-hover/link:translate-x-1" />
+                      </Link>
+                    </div>
+                  </div>
+                </CarouselItem>
+              ))}
+            </CarouselContent>
+            <CarouselPrevious className="-left-2 md:-left-6" />
+            <CarouselNext className="-right-2 md:-right-6" />
+          </Carousel>
+        </div>
       </div>
     </section>
   );

--- a/src/components/home/FeaturedCourses.tsx
+++ b/src/components/home/FeaturedCourses.tsx
@@ -1,9 +1,9 @@
 "use client";
-
 import { Link } from "@/i18n/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { motion } from "framer-motion";
-import { ArrowRight, Star } from "lucide-react";
+import { ArrowRight, BookOpen, Clock, GraduationCap } from "lucide-react";
+import Image from "next/image";
 import Autoplay from "embla-carousel-autoplay";
 import {
   Carousel,
@@ -24,21 +24,85 @@ const fadeInUp = {
 };
 
 /**
- * Locale-aware titles for featured courses.
- * When the registry grows, this could be replaced by loading from content files.
+ * Locale-aware content for featured courses (bookshelf-style).
  */
-const TITLES: Record<string, Record<string, { title: string; desc: string }>> = {
+const COURSE_DATA: Record<string, Record<string, { title: string; desc: string; duration: string; level: string; tags: string[] }>> = {
   "oet-preparation": {
     "zh-CN": {
       title: "OET 备考课程",
-      desc: "提升您的医学英语能力，助力成功通过 OET 考试。",
+      desc: "系统化提升医学英语听说读写能力，针对 OET 考试各模块进行专项训练，助力医疗专业人士顺利通过国际认证。",
+      duration: "12 周",
+      level: "中高级",
+      tags: ["考试备考", "国际认证", "医学英语"],
     },
     en: {
       title: "OET Preparation",
-      desc: "Boost your medical English skills and help you achieve success in the OET exam.",
+      desc: "Systematically improve medical English across all four skills with module-specific training designed to help healthcare professionals pass this international certification.",
+      duration: "12 Weeks",
+      level: "Upper-Intermediate",
+      tags: ["Exam Prep", "Certification", "Medical English"],
+    },
+  },
+  "medical-english-for-doctors": {
+    "zh-CN": {
+      title: "医生英语",
+      desc: "面向临床医生的专业英语沟通课程，涵盖病史采集、查体描述、医患沟通等核心场景，提升国际诊疗能力。",
+      duration: "8 周",
+      level: "中级",
+      tags: ["临床沟通", "医患对话", "查房英语"],
+    },
+    en: {
+      title: "Medical English for Doctors",
+      desc: "Professional English communication for clinicians covering history-taking, physical examination descriptions, and patient consultations in international settings.",
+      duration: "8 Weeks",
+      level: "Intermediate",
+      tags: ["Clinical", "Consultation", "Ward Rounds"],
+    },
+  },
+  "medical-english-for-nurses": {
+    "zh-CN": {
+      title: "护士英语",
+      desc: "护理专业英语沟通能力提升课程，覆盖交接班、患者教育、多学科协作等护理核心场景。",
+      duration: "8 周",
+      level: "中级",
+      tags: ["护理沟通", "交接班", "患者教育"],
+    },
+    en: {
+      title: "Medical English for Nurses",
+      desc: "Nursing-specific English communication covering handovers, patient education, and multidisciplinary team collaboration scenarios.",
+      duration: "8 Weeks",
+      level: "Intermediate",
+      tags: ["Nursing", "Handover", "Patient Education"],
+    },
+  },
+  "pre-departure-medical-english": {
+    "zh-CN": {
+      title: "出国前医学英语",
+      desc: "12 周强化语言项目，专为即将海外临床实习的医疗专业人士打造，涵盖文化适应与临床场景双重准备。",
+      duration: "12 周",
+      level: "中高级",
+      tags: ["海外实习", "文化适应", "强化训练"],
+    },
+    en: {
+      title: "Pre-departure Medical English",
+      desc: "A 12-week intensive programme for healthcare professionals preparing for overseas clinical placements, covering both cultural adaptation and clinical scenarios.",
+      duration: "12 Weeks",
+      level: "Upper-Intermediate",
+      tags: ["Overseas", "Cultural Prep", "Intensive"],
     },
   },
 };
+
+/* Hero images for bookshelf covers */
+const COVER_IMAGES: Record<string, string> = {
+  "oet-preparation": "/images/hero/oet-preparation.webp",
+  "medical-english-for-doctors": "/images/hero/medical-english.webp",
+  "medical-english-for-nurses": "/images/hero/medical-english.webp",
+  "pre-departure-medical-english": "/images/hero/observership.webp",
+};
+
+/* Spine colors for bookshelf effect */
+const SPINE_COLORS = ["#00438A", "#1A5BA0", "#2D6DB8", "#C4922A"];
 
 export default function FeaturedCourses() {
   const t = useTranslations("home");
@@ -48,7 +112,7 @@ export default function FeaturedCourses() {
   if (featured.length === 0) return null;
 
   return (
-    <section className="section-padding bg-white">
+    <section className="section-padding bg-[#FAFBFD]">
       <div className="container">
         <motion.div
           initial="hidden"
@@ -68,53 +132,113 @@ export default function FeaturedCourses() {
           </motion.h2>
         </motion.div>
 
-        <div className="max-w-5xl mx-auto px-12">
+        <div className="max-w-6xl mx-auto px-4 md:px-12">
           <Carousel
             opts={{ align: "start", loop: true }}
             plugins={[
-              Autoplay({ delay: 4000, stopOnInteraction: true, stopOnMouseEnter: true }),
+              Autoplay({ delay: 5000, stopOnInteraction: true, stopOnMouseEnter: true }),
             ]}
           >
-            <CarouselContent className="-ml-4">
-              {featured.map((prog) => {
-                const localeData = TITLES[prog.slug]?.[locale] ?? {
+            <CarouselContent className="-ml-5">
+              {featured.map((prog, idx) => {
+                const data = COURSE_DATA[prog.slug]?.[locale] || COURSE_DATA[prog.slug]?.["zh-CN"] || {
                   title: prog.title,
                   desc: prog.shortDescription,
+                  duration: "",
+                  level: "",
+                  tags: [],
                 };
+                const coverImage = COVER_IMAGES[prog.slug] || "/images/hero/medical-english.webp";
+                const spineColor = SPINE_COLORS[idx % SPINE_COLORS.length];
 
                 return (
                   <CarouselItem
                     key={prog.slug}
-                    className="pl-4 basis-full sm:basis-1/2 lg:basis-1/3"
+                    className="pl-5 basis-full sm:basis-1/2"
                   >
                     <Link
                       href={`/programmes/${prog.category}/${prog.slug}` as never}
                       className="no-underline block group h-full"
                     >
-                      <div className="bg-white rounded-xl p-6 border-2 border-[#E3E5EC] hover:border-[#00438A]/20 shadow-sm hover:shadow-lg hover:-translate-y-1 transition-all duration-300 h-full flex flex-col">
-                        <div className="flex items-center gap-2 mb-4">
-                          <Star className="w-4 h-4 text-[#C4922A]" />
-                          <span className="text-xs font-medium text-[#C4922A] uppercase tracking-wide">
-                            {locale === "zh-CN" ? "精选" : "Featured"}
+                      {/* Bookshelf-style card: spine + cover + content */}
+                      <div className="relative h-full rounded-xl overflow-hidden border border-[#E3E5EC]/80 bg-white shadow-md hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
+                        {/* Spine accent */}
+                        <div
+                          className="absolute left-0 top-0 bottom-0 w-1.5 z-10"
+                          style={{ backgroundColor: spineColor }}
+                        />
+
+                        {/* Cover image area */}
+                        <div className="relative h-44 md:h-52 overflow-hidden">
+                          <Image
+                            src={coverImage}
+                            alt={data.title}
+                            fill
+                            className="object-cover transition-transform duration-500 group-hover:scale-105"
+                            sizes="(max-width: 640px) 100vw, 50vw"
+                          />
+                          <div className="absolute inset-0 bg-gradient-to-t from-[#0A1628]/60 to-transparent" />
+                          {/* Category badge */}
+                          <div className="absolute top-4 left-5 flex items-center gap-1.5 bg-white/90 backdrop-blur-sm rounded-full px-3 py-1">
+                            <GraduationCap className="w-3.5 h-3.5 text-[#00438A]" />
+                            <span className="text-[11px] font-medium text-[#00438A]">
+                              {locale === "zh-CN" ? "精选" : "Featured"}
+                            </span>
+                          </div>
+                        </div>
+
+                        {/* Content area */}
+                        <div className="flex-1 p-5 md:p-6 pl-6 md:pl-7 flex flex-col">
+                          <h3 className="font-display text-lg md:text-xl font-bold text-[#0A1628] mb-2 group-hover:text-[#00438A] transition-colors leading-tight">
+                            {data.title}
+                          </h3>
+                          <p className="text-sm text-[#3C3A47] leading-relaxed mb-4 flex-1 line-clamp-3">
+                            {data.desc}
+                          </p>
+
+                          {/* Meta info */}
+                          <div className="flex items-center gap-4 mb-4 text-xs text-[#8A889A]">
+                            {data.duration && (
+                              <span className="flex items-center gap-1">
+                                <Clock className="w-3.5 h-3.5" />
+                                {data.duration}
+                              </span>
+                            )}
+                            {data.level && (
+                              <span className="flex items-center gap-1">
+                                <BookOpen className="w-3.5 h-3.5" />
+                                {data.level}
+                              </span>
+                            )}
+                          </div>
+
+                          {/* Tags */}
+                          {data.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-1.5 mb-4">
+                              {data.tags.map((tag) => (
+                                <span
+                                  key={tag}
+                                  className="text-[10px] font-medium px-2 py-0.5 rounded-full bg-[#00438A]/5 text-[#00438A] border border-[#00438A]/10"
+                                >
+                                  {tag}
+                                </span>
+                              ))}
+                            </div>
+                          )}
+
+                          {/* CTA */}
+                          <span className="inline-flex items-center gap-1.5 text-sm font-medium text-[#00438A] group-hover:gap-2.5 transition-all mt-auto">
+                            {t("pillars.explore")} <ArrowRight className="w-4 h-4" />
                           </span>
                         </div>
-                        <h3 className="font-semibold text-lg text-[#0E0C19] mb-2 group-hover:text-[#00438A] transition-colors">
-                          {localeData.title}
-                        </h3>
-                        <p className="text-sm text-[#3C3A47] leading-relaxed mb-4 flex-1">
-                          {localeData.desc}
-                        </p>
-                        <span className="inline-flex items-center gap-1 text-sm font-medium text-[#00438A] group-hover:gap-2 transition-all">
-                          {t("pillars.explore")} <ArrowRight className="w-4 h-4" />
-                        </span>
                       </div>
                     </Link>
                   </CarouselItem>
                 );
               })}
             </CarouselContent>
-            <CarouselPrevious />
-            <CarouselNext />
+            <CarouselPrevious className="-left-2 md:-left-6" />
+            <CarouselNext className="-right-2 md:-right-6" />
           </Carousel>
         </div>
       </div>


### PR DESCRIPTION
## Issue #81

### Part 1: Case Study → Sliding Carousel
**Before**: Single hardcoded maternity hospital case
**After**: Embla-carousel with full-width sliding cards

- 2 cases: maternity hospital (84% improvement) + Indonesia TCM rehab (cross-border localised care)
- Each card: left image with quote overlay + right side metrics grid + description + CTA
- 7s autoplay, loop, prev/next navigation
- Array-driven data — adding new cases only requires pushing to the array

### Part 2: Featured Courses → Bookshelf Style
**Before**: Small 1/3-width cards with minimal info
**After**: Large 1/2-width bookshelf-style cards

Visual design:
- Colored spine accent (left edge, per-card color)
- Cover image from existing hero assets (h-44/h-52)
- Rich content: title, 3-line description, duration, level, tags
- Category badge overlay on image
- Hover: shadow + lift + image zoom

**TypeScript**: 0 errors | **Zero new deps**

Closes #81