### PR TITLE
fix: enlarge header logo with backdrop + remove MedNav dark CTA (B1+B2)

### DIFF
--- a/src/app/[locale]/medical-navigator/page.tsx
+++ b/src/app/[locale]/medical-navigator/page.tsx
@@ -444,38 +444,7 @@ export default function MedicalNavigatorPage() {
         </div>
       </section>
 
-      {/* ═══════════════════════════════════════════════════
-          § 8  DARK CTA BAR
-          ═══════════════════════════════════════════════════ */}
-      <section className="bg-[#0A1628] py-16 md:py-20">
-        <div className="container text-center">
-          <FadeIn>
-            <h2 className="font-display text-2xl md:text-3xl lg:text-4xl font-bold text-white mb-8 max-w-2xl mx-auto">
-              {t2(content.darkCta.title, locale)}
-            </h2>
-            <div className="flex flex-wrap items-center justify-center gap-4">
-              <Link
-                href="/contact"
-                className="inline-flex items-center gap-2 px-7 py-3.5 bg-[#C4922A] text-white font-medium rounded-md hover:bg-[#A87822] transition-colors no-underline shadow-lg shadow-[#C4922A]/25"
-              >
-                {t2(content.darkCta.cta1, locale)}
-                <ArrowRight className="w-4 h-4" />
-              </Link>
-              {/* TODO: Link to actual service guide PDF when available */}
-              <button
-                type="button"
-                className="inline-flex items-center gap-2 px-7 py-3.5 border-2 border-white/30 text-white font-medium rounded-md hover:bg-white/10 transition-colors"
-                onClick={() => {
-                  // Placeholder — toast or download when PDF is ready
-                  alert(locale === "zh-CN" ? "服务手册即将上线" : "Service guide coming soon");
-                }}
-              >
-                {t2(content.darkCta.cta2, locale)}
-              </button>
-            </div>
-          </FadeIn>
-        </div>
-      </section>
+
     </>
   );
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -86,11 +86,13 @@ export default function Header() {
       <div className="container flex items-center justify-between h-[72px] md:h-20">
         {/* Logo */}
         <Link href="/" className="flex items-center gap-2.5 no-underline shrink-0">
-          <img
-            src="/brand/logo-128.png"
-            alt="Mediversity Global"
-            className="h-9 md:h-10 w-auto"
-          />
+          <span className={`inline-flex items-center justify-center rounded-lg transition-all duration-300 ${scrolled || !isHome ? 'bg-transparent' : 'bg-white/90 backdrop-blur-sm shadow-sm'} p-1`}>
+            <img
+              src="/brand/logo-128.png"
+              alt="Mediversity Global"
+              className="h-10 md:h-12 w-auto"
+            />
+          </span>
           <span className={`font-display text-lg md:text-xl font-bold tracking-tight transition-colors duration-300 ${logoColor} hidden sm:inline`}>
             Mediversity<span className="font-light ml-1">Global</span>
           </span>


### PR DESCRIPTION
## 巡视修补 PR

### B1 — Logo 视觉调整
**问题**：Logo 在 hero 图上太小，与背景融合辨识度不够
**修复**：
- 放大 Logo：h-9/h-10 → h-10/h-12
- 在 hero 页面（未滚动时）给 Logo 加白色半透明底板（`bg-white/90 backdrop-blur-sm shadow-sm rounded-lg`）
- 滚动后或非首页时底板自动消失（保持简洁）

### B2 — /medical-navigator 删除底部 CTA
**问题**：底部「让我们帮您把健康这件事想清楚」dark CTA 多余
**修复**：直接移除该 section（上方 Contact section 已有完整联系方式 + CTA 按钮）

**TypeScript**: 0 errors | **零新依赖**