### PR TITLE
fix: P0 bugs — unpublished courses, OET 5 display modes, testimonials i18n

### DIFF
--- a/content/programmes/medical-english/en/oet-preparation.ts
+++ b/content/programmes/medical-english/en/oet-preparation.ts
@@ -86,6 +86,114 @@ const data: ProgrammeData = {
       ],
     },
 
+    /* ── Learning Objectives (step list) ── */
+    {
+      type: "value-props",
+      title: "Learning Objectives",
+      display: "list",
+      items: [
+        {
+          title: "Master all four OET modules",
+          description: "Systematically develop Listening, Reading, Writing, and Speaking skills for both exam success and real-world clinical communication.",
+        },
+        {
+          title: "Navigate authentic clinical communication",
+          description: "Through role-plays and case studies, master patient history-taking, handovers, and patient education communication patterns.",
+        },
+        {
+          title: "Achieve OET Grade B or above",
+          description: "With structured training and mock exam feedback, reach the OET B standard recognised by UK GMC/NMC for professional registration.",
+        },
+        {
+          title: "Build cross-cultural communication confidence",
+          description: "Develop the ability to communicate naturally in English-speaking healthcare environments, fully prepared for overseas practice.",
+        },
+      ],
+    },
+    /* ── Teaching Methodology (timeline) ── */
+    {
+      type: "value-props",
+      title: "Teaching Methodology",
+      display: "timeline",
+      items: [
+        {
+          title: "Entry Assessment",
+          description: "Comprehensive evaluation of English proficiency and weak areas to create a personalised study plan.",
+        },
+        {
+          title: "Structured Curriculum",
+          description: "Expert-led live classes + recorded replays covering all four OET module core exam points.",
+        },
+        {
+          title: "Practical Drills",
+          description: "Role-plays, simulated consultations, timed writing, and other immersive practice activities.",
+        },
+        {
+          title: "Mock Exam Feedback",
+          description: "Full simulation exams + one-on-one in-depth feedback from certified OET trainers.",
+        },
+        {
+          title: "Final Sprint",
+          description: "Pre-exam intensive review, gap analysis, and confidence building for test day.",
+        },
+      ],
+    },
+    /* ── Course Syllabus (table) ── */
+    {
+      type: "value-props",
+      title: "Course Syllabus",
+      display: "table",
+      items: [
+        {
+          title: "Listening Module",
+          description: "Medical consultation comprehension, key information extraction, note-taking techniques",
+        },
+        {
+          title: "Reading Module",
+          description: "Rapid medical literature reading, information location, professional vocabulary building",
+        },
+        {
+          title: "Writing Module",
+          description: "Referral letters and discharge summaries, clinical correspondence format and language conventions",
+        },
+        {
+          title: "Speaking Module",
+          description: "Role-plays (history-taking, explaining diagnoses, patient education), fluency and pronunciation training",
+        },
+        {
+          title: "Integrated Mock Exams",
+          description: "Full simulation exam environment, timed completion, immediate scoring and feedback",
+        },
+        {
+          title: "Pre-Exam Sprint",
+          description: "High-frequency topic review, exam strategies, psychological preparation and time management",
+        },
+      ],
+    },
+    /* ── Course Highlights (accordion) ── */
+    {
+      type: "value-props",
+      title: "Course Highlights",
+      display: "accordion",
+      items: [
+        {
+          title: "Small class sizes, maximum interaction",
+          description: "Classes of no more than 8 students ensure ample practice opportunities and personalised guidance for every learner.",
+        },
+        {
+          title: "Authentic clinical scenario simulation",
+          description: "All teaching materials and exercises are designed around real healthcare scenarios for practical application.",
+        },
+        {
+          title: "Flexible learning arrangements",
+          description: "Live classes + recorded replays + one-on-one tutoring to accommodate different work schedules.",
+        },
+        {
+          title: "Continuous tracking and support",
+          description: "Learning advisors track progress throughout, with regular assessments and study plan adjustments.",
+        },
+      ],
+    },
     /* ── OET Online Learning Platform ── */
     {
       type: "delivery-format",

--- a/content/programmes/medical-english/zh-CN/oet-preparation.ts
+++ b/content/programmes/medical-english/zh-CN/oet-preparation.ts
@@ -86,6 +86,114 @@ const data: ProgrammeData = {
       ],
     },
 
+    /* ── 学习目标（step list） ── */
+    {
+      type: "value-props",
+      title: "学习目标",
+      display: "list",
+      items: [
+        {
+          title: "掌握 OET 四大模块核心技能",
+          description: "系统学习听力、阅读、写作和口语，全面提升医学英语应试与实战能力。",
+        },
+        {
+          title: "熟悉真实医疗场景沟通模式",
+          description: "通过角色扮演和案例分析，掌握病史采集、交接班、患者教育等临床沟通技巧。",
+        },
+        {
+          title: "达到 OET B 级以上水平",
+          description: "通过系统训练和模考反馈，帮助学员达到英国 GMC/NMC 认可的 OET B 级标准。",
+        },
+        {
+          title: "建立跨文化沟通自信",
+          description: "培养在英语医疗环境中自如交流的能力，为海外执业做好充分准备。",
+        },
+      ],
+    },
+    /* ── 教学方式（timeline） ── */
+    {
+      type: "value-props",
+      title: "教学方式",
+      display: "timeline",
+      items: [
+        {
+          title: "入学评估",
+          description: "全面测评英语水平与薄弱环节，制定个性化学习计划。",
+        },
+        {
+          title: "系统课程",
+          description: "专家主讲直播课 + 录播回放，覆盖 OET 四大模块核心考点。",
+        },
+        {
+          title: "实战演练",
+          description: "角色扮演、模拟问诊、限时写作等沉浸式练习。",
+        },
+        {
+          title: "模考反馈",
+          description: "全真模拟考试 + 认证培训师一对一深度反馈。",
+        },
+        {
+          title: "冲刺备考",
+          description: "考前集中强化，查漏补缺，建立应试信心。",
+        },
+      ],
+    },
+    /* ── 课程大纲（table） ── */
+    {
+      type: "value-props",
+      title: "课程大纲",
+      display: "table",
+      items: [
+        {
+          title: "听力模块",
+          description: "医疗咨询录音理解、关键信息提取、笔记技巧训练",
+        },
+        {
+          title: "阅读模块",
+          description: "医学文献快速阅读、信息定位、专业词汇积累",
+        },
+        {
+          title: "写作模块",
+          description: "转介信/出院小结撰写、临床信函格式与语言规范",
+        },
+        {
+          title: "口语模块",
+          description: "角色扮演（病史采集、解释诊断、患者教育）、流利度与发音训练",
+        },
+        {
+          title: "综合模考",
+          description: "全真模拟考试环境、限时完成、即时评分与反馈",
+        },
+        {
+          title: "考前冲刺",
+          description: "高频考点回顾、应试策略、心理调适与时间管理",
+        },
+      ],
+    },
+    /* ── 课程亮点（accordion） ── */
+    {
+      type: "value-props",
+      title: "课程亮点",
+      display: "accordion",
+      items: [
+        {
+          title: "小班教学，充分互动",
+          description: "每班不超过 8 人，确保每位学员获得充足的练习机会和个性化指导。",
+        },
+        {
+          title: "真实临床场景模拟",
+          description: "所有教学材料和练习均基于真实医疗场景设计，学以致用。",
+        },
+        {
+          title: "灵活学习安排",
+          description: "支持直播课 + 录播回放 + 一对一辅导，适应不同工作节奏。",
+        },
+        {
+          title: "持续跟踪与支持",
+          description: "学习顾问全程跟踪进度，定期评估并调整学习计划。",
+        },
+      ],
+    },
     /* ── OET 在线学习平台 ── */
     {
       type: "delivery-format",

--- a/src/app/[locale]/programmes/medical-english/page.tsx
+++ b/src/app/[locale]/programmes/medical-english/page.tsx
@@ -33,7 +33,7 @@ const subcategories: SubCategory[] = [
     titleKey: "clinical",
     descKey: "clinicalDesc",
     courses: [
-      { titleKey: "workplaceMedicalEnglish", status: "active" },
+      { titleKey: "workplaceMedicalEnglish", status: "future" },
       { titleKey: "medicalEnglishDoctors", status: "active", slug: "medical-english-for-doctors", cover: "/images/courses/medical-english-for-doctors.webp", description: "医疗专业人员语言沟通能力提升课程" },
       { titleKey: "medicalEnglishNurses", status: "active", slug: "medical-english-for-nurses", cover: "/images/courses/medical-english-for-nurses.webp", description: "护士专属医学英语沟通能力提升课程" },
       { titleKey: "clinicalConsultationEnglish", status: "future" },

--- a/src/app/[locale]/programmes/observership/page.tsx
+++ b/src/app/[locale]/programmes/observership/page.tsx
@@ -10,7 +10,7 @@ const subcategories: SubCategory[] = [
     titleKey: "clinicalObserver",
     descKey: "clinicalObserverDesc",
     courses: [
-      { titleKey: "shortTermObservership", status: "active" },
+      { titleKey: "shortTermObservership", status: "future" },
       { titleKey: "specialtyBasedObservership", status: "future" },
       { titleKey: "hospitalAttachment", status: "future" },
     ],
@@ -21,7 +21,7 @@ const subcategories: SubCategory[] = [
     titleKey: "advancedClinical",
     descKey: "advancedClinicalDesc",
     courses: [
-      { titleKey: "advancedClinicalObserver", status: "active" },
+      { titleKey: "advancedClinicalObserver", status: "future" },
       { titleKey: "consultantShadowing", status: "future" },
       { titleKey: "departmentImmersion", status: "future" },
     ],
@@ -32,7 +32,7 @@ const subcategories: SubCategory[] = [
     titleKey: "visitingScholar",
     descKey: "visitingScholarDesc",
     courses: [
-      { titleKey: "visitingScholarProgramme", status: "active" },
+      { titleKey: "visitingScholarProgramme", status: "future" },
       { titleKey: "researchAttachment", status: "future" },
       { titleKey: "internationalAcademicExchange", status: "future" },
     ],

--- a/src/components/programmes/PillarLandingPage.tsx
+++ b/src/components/programmes/PillarLandingPage.tsx
@@ -128,7 +128,9 @@ export default function PillarLandingPage({
       </HeroSection>
 
       {/* ═══ Subcategories ═══ */}
-      {subcategories.map((sub, idx) => {
+      {subcategories
+        .filter((sub) => sub.courses.some((c) => c.status === "active"))
+        .map((sub, idx) => {
         const Icon = sub.icon;
         const active = sub.courses.filter((c) => c.status === "active");
         const isEven = idx % 2 === 0;

--- a/src/components/programmes/ProgramDetailTemplate.tsx
+++ b/src/components/programmes/ProgramDetailTemplate.tsx
@@ -352,6 +352,7 @@ function ValuePropsAccordion({ section, isAlt }: { section: ValuePropsSection; i
 
 /* ── Value Props: TABLE (structured data table for syllabus/curriculum) ── */
 function ValuePropsTable({ section, isAlt }: { section: ValuePropsSection; isAlt?: boolean }) {
+  const t = useTranslations("common");
   return (
     <section
       className="section-padding"
@@ -369,8 +370,8 @@ function ValuePropsTable({ section, isAlt }: { section: ValuePropsSection; isAlt
               <thead>
                 <tr style={{ backgroundColor: "var(--brand-primary)" }}>
                   <th className="px-6 py-4 text-left text-sm font-semibold text-white w-16">#</th>
-                  <th className="px-6 py-4 text-left text-sm font-semibold text-white">模块</th>
-                  <th className="px-6 py-4 text-left text-sm font-semibold text-white hidden md:table-cell">内容</th>
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-white">{t("tableModule")}</th>
+                  <th className="px-6 py-4 text-left text-sm font-semibold text-white hidden md:table-cell">{t("tableContent")}</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -383,7 +383,10 @@
     "activeCourses": "active courses",
     "futureCourses": "planned courses",
     "futureProgrammes": "Future Programmes",
-    "viewDetails": "View details"
+    "viewDetails": "View details",
+    "testimonials": "Student Testimonials",
+    "tableModule": "Module",
+    "tableContent": "Content"
   },
   "footer": {
     "ctaTitle": "Ready to Get Started?",

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -383,7 +383,10 @@
     "activeCourses": "门在授课程",
     "futureCourses": "门规划中课程",
     "futureProgrammes": "规划中的课程",
-    "viewDetails": "查看详情"
+    "viewDetails": "查看详情",
+    "testimonials": "学员评价",
+    "tableModule": "模块",
+    "tableContent": "内容"
   },
   "footer": {
     "ctaTitle": "准备好开始了吗？",


### PR DESCRIPTION
## P0 Fixes

### P0-1: 未上线课程仍渲染
- `PillarLandingPage.tsx`: 新增 `.filter()` 在 `subcategories.map()` 前过滤掉没有 active 课程的分类
- `medical-english/page.tsx`: `workplaceMedicalEnglish` 已改为 `future`（之前已修）
- `observership/page.tsx`: 所有无 slug 课程已改为 `future`（之前已修）
- 效果：空分类整组不显示

### P0-2: OET 详情页完整展示 5 种 display 模式
- `oet-preparation.ts` (zh-CN + en) 新增 4 个 value-props section:
  - `display: "list"` → 学习目标 / Learning Objectives
  - `display: "timeline"` → 教学方式 / Teaching Methodology
  - `display: "table"` → 课程大纲 / Course Syllabus
  - `display: "accordion"` → 课程亮点 / Course Highlights
- 原有 `display: "grid"` 保留（为什么选择我们）
- Table 表头改为 i18n（`common.tableModule` / `common.tableContent`）

### P0-3: testimonials i18n key 缺失
- `src/messages/zh-CN.json` + `en.json`: 新增 `common.testimonials`
- 页面不再显示 raw key `common.testimonials`

Closes #83 (partial) · Closes #84 (partial)