### PR TITLE
fix: P1 visual — carousel arrows outside cards + hub spacing tightened

### DIFF
--- a/src/app/[locale]/programmes/page.tsx
+++ b/src/app/[locale]/programmes/page.tsx
@@ -105,7 +105,7 @@ export default function ProgrammesHubPage() {
       </HeroSection>
 
       {/* ═══ Philosophy — 4 core principles (Issue #72: pipeline infographic) ═══ */}
-      <section className="section-padding bg-white relative overflow-hidden">
+      <section className="pt-16 md:pt-20 pb-10 md:pb-14 bg-white relative overflow-hidden">
         <DotPattern opacity={0.02} />
         <div className="container relative z-10">
           <motion.div
@@ -224,7 +224,7 @@ export default function ProgrammesHubPage() {
       </section>
 
       {/* ═══ Pillar Cards ═══ */}
-      <section className="section-padding bg-white relative overflow-hidden">
+      <section className="py-10 md:py-14 bg-white relative overflow-hidden">
         {/* Decorative elements */}
         <DotPattern opacity={0.03} />
         <FloatingShape
@@ -340,7 +340,7 @@ export default function ProgrammesHubPage() {
       <WaveDivider fromColor="#FFFFFF" toColor="#F5F3EF" />
 
       {/* ═══ Bottom CTA ═══ */}
-      <section className="section-padding bg-[#F5F3EF] relative overflow-hidden">
+      <section className="py-10 md:py-14 bg-[#F5F3EF] relative overflow-hidden">
         <CornerAccent position="top-right" color="#00438A" size={100} />
         <CornerAccent position="bottom-left" color="#C4922A" size={80} />
 

--- a/src/components/home/CaseStudyHighlight.tsx
+++ b/src/components/home/CaseStudyHighlight.tsx
@@ -250,8 +250,8 @@ export default function CaseStudyHighlight() {
                 </CarouselItem>
               ))}
             </CarouselContent>
-            <CarouselPrevious className="-left-2 md:-left-6" />
-            <CarouselNext className="-right-2 md:-right-6" />
+            <CarouselPrevious className="-left-4 md:-left-14 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
+            <CarouselNext className="-right-4 md:-right-14 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
           </Carousel>
         </div>
       </div>

--- a/src/components/home/FeaturedCourses.tsx
+++ b/src/components/home/FeaturedCourses.tsx
@@ -237,8 +237,8 @@ export default function FeaturedCourses() {
                 );
               })}
             </CarouselContent>
-            <CarouselPrevious className="-left-2 md:-left-6" />
-            <CarouselNext className="-right-2 md:-right-6" />
+            <CarouselPrevious className="-left-4 md:-left-14 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
+            <CarouselNext className="-right-4 md:-right-14 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
           </Carousel>
         </div>
       </div>

--- a/src/components/medical-navigator/CaseShowcase.tsx
+++ b/src/components/medical-navigator/CaseShowcase.tsx
@@ -234,8 +234,8 @@ export default function CaseShowcase({
                   </CarouselItem>
                 ))}
               </CarouselContent>
-              <CarouselPrevious />
-              <CarouselNext />
+              <CarouselPrevious className="-left-4 md:-left-12 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
+              <CarouselNext className="-right-4 md:-right-12 h-9 w-9 bg-white/90 backdrop-blur-sm shadow-md border-[#00438A]/20 hover:bg-[#00438A] hover:text-white transition-colors" />
             </Carousel>
           </div>
         </FadeIn>


### PR DESCRIPTION
## P1 Visual Fixes

### P1-1: Carousel 箭头跟卡片重叠
- **CaseStudyHighlight** (首页成功案例): 箭头外移至 `-left-14 / -right-14`
- **FeaturedCourses** (首页精选课程): 同上
- **CaseShowcase** (MedNav 缩略导航): 同上
- 统一样式: `h-9 w-9`、半透明白底 + backdrop-blur、brand 色 hover

### P1-2: /programmes hub 间距过大
- 「培养国际化医疗专业能力」→「四大培训板块」: 间距从 `6rem` 减至 `2.5rem`
- 4 个 pillar 卡片 →「不确定从哪里开始？」: 间距从 `6rem` 减至 `2.5rem`
- Philosophy section 底部 padding 也相应收紧