### PR TITLE
feat(programmes): apply OET display modes pattern to 8 published courses

### DIFF
--- a/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Empathy-driven care — core skills for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/humanities.webp",
-    imageAlt: "Medical humanities and professional development",
+    image: "/images/courses/medical-humanities-and-communication-skills.webp",
+    imageAlt: "Medical Humanities & Communication Skills Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "培养人文价值观与以患者为中心的思维模式",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Teaching Methods",
+      display: "timeline",
       items: [
         {
           title: "高仿真案例教学",
@@ -79,6 +81,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 医学人文与职业身份认同",

--- a/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Reading disease with expertise, delivering care through dialogue",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/humanities.webp",
-    imageAlt: "Medical humanities and professional development",
+    image: "/images/courses/medical-humanities-and-general-practice-literacy.webp",
+    imageAlt: "Medical Humanities & General Practice Literacy Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "通过医学人文核心理念培养人文关怀",
@@ -61,6 +62,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Teaching Methods",
+      display: "timeline",
       items: [
         {
           title: "案例分析",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 医学人文导论：医学不仅是科学，更是人文",

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-communication-skills.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "提升共情照护：赋能医疗从业者的核心技能",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/humanities.webp",
-    imageAlt: "医学人文与职业发展",
+    image: "/images/courses/medical-humanities-and-communication-skills.webp",
+    imageAlt: "医学人文与沟通技能课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "培养人文价值观与以患者为中心的思维模式",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "教学方法",
+      display: "timeline",
       items: [
         {
           title: "高仿真案例教学",
@@ -79,6 +81,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 医学人文与职业身份认同",

--- a/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/zh-CN/medical-humanities-and-general-practice-literacy.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "用专业解读疾病，用对话传递关怀",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/humanities.webp",
-    imageAlt: "医学人文与职业发展",
+    image: "/images/courses/medical-humanities-and-general-practice-literacy.webp",
+    imageAlt: "医学人文与全科医学素养课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "通过医学人文核心理念培养人文关怀",
@@ -61,6 +62,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "教学方法",
+      display: "timeline",
       items: [
         {
           title: "案例分析",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 医学人文导论：医学不仅是科学，更是人文",

--- a/content/programmes/medical-english/en/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/en/medical-english-for-doctors.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Language and Communication Skills Programme for Healthcare Professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "Medical English & Clinical Communication training",
+    image: "/images/courses/medical-english-for-doctors.webp",
+    imageAlt: "Medical English for Doctors Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "掌握医学术语：熟练运用专业医学词汇，确保精准的医患沟通",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Teaching Methods",
+      display: "timeline",
       items: [
         {
           title: "互动教学与合作学习",
@@ -91,6 +93,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Key Features",
+      display: "grid",
       items: [
         {
           title: "全面定制化学习路径",
@@ -121,6 +124,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "基础知识",

--- a/content/programmes/medical-english/en/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/en/medical-english-for-nurses.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "An advanced, practice-oriented 50-lesson programme tailored for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "Medical English & Clinical Communication training",
+    image: "/images/courses/medical-english-for-nurses.webp",
+    imageAlt: "Medical English for Nurses Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "医学术语发展：全面掌握医学术语及其在临床中的应用",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Teaching Methods",
+      display: "timeline",
       items: [
         {
           title: "互动与协作学习",
@@ -91,6 +93,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Key Features",
+      display: "grid",
       items: [
         {
           title: "全面且个性化的学习路径",
@@ -121,6 +124,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "基础知识",

--- a/content/programmes/medical-english/en/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/en/pre-departure-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "A 12-week intensive language programme for healthcare professionals preparing for overseas clinical placement",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "Medical English & Clinical Communication training",
+    image: "/images/courses/pre-departure-medical-english.webp",
+    imageAlt: "Pre-departure Medical English Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "真实情境模拟",
@@ -49,6 +50,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Key Features",
+      display: "grid",
       items: [
         {
           title: "教学策略可根据您的需求量身定制",
@@ -95,6 +97,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 在不同医疗场景下自我介绍",

--- a/content/programmes/medical-english/en/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/en/preparatory-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "A 12-lesson foundation programme for healthcare professionals preparing for advanced medical English training",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "Medical English & Clinical Communication training",
+    image: "/images/courses/preparatory-medical-english.webp",
+    imageAlt: "Preparatory Medical English Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "系统性学习语法应用自信",
@@ -53,6 +54,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Key Features",
+      display: "grid",
       items: [
         {
           title: "基础场景实战闭环",
@@ -79,6 +81,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 身体与创伤",

--- a/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-doctors.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "医疗专业人员语言沟通能力提升课程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "医学英语与沟通能力培训",
+    image: "/images/courses/medical-english-for-doctors.webp",
+    imageAlt: "医生英语课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "掌握医学术语：熟练运用专业医学词汇，确保精准的医患沟通",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "教学方法",
+      display: "timeline",
       items: [
         {
           title: "互动教学与合作学习",
@@ -91,6 +93,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "核心特色",
+      display: "grid",
       items: [
         {
           title: "全面定制化学习路径",
@@ -121,6 +124,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "基础知识",

--- a/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/zh-CN/medical-english-for-nurses.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "一个为医疗专业人员量身定制的高级实践导向 50 节课程，旨在提升其语言能力和沟通技巧",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "医学英语与沟通能力培训",
+    image: "/images/courses/medical-english-for-nurses.webp",
+    imageAlt: "护士英语课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "医学术语发展：全面掌握医学术语及其在临床中的应用",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "教学方法",
+      display: "timeline",
       items: [
         {
           title: "互动与协作学习",
@@ -91,6 +93,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "核心特色",
+      display: "grid",
       items: [
         {
           title: "全面且个性化的学习路径",
@@ -121,6 +124,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "基础知识",

--- a/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/pre-departure-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "为期 12 周的语言强化课程，专为即将赴海外进行临床实习的医疗专业人员设计",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "医学英语与沟通能力培训",
+    image: "/images/courses/pre-departure-medical-english.webp",
+    imageAlt: "出国前医学英语课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "真实情境模拟",
@@ -49,6 +50,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "核心特色",
+      display: "grid",
       items: [
         {
           title: "教学策略可根据您的需求量身定制",
@@ -95,6 +97,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 在不同医疗场景下自我介绍",

--- a/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/zh-CN/preparatory-medical-english.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "12 课时基础英语课程，专为医疗从业者设计，为其进阶医疗英语培训奠定基础",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/medical-english.webp",
-    imageAlt: "医学英语与沟通能力培训",
+    image: "/images/courses/preparatory-medical-english.webp",
+    imageAlt: "预备通用英语课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "系统性学习语法应用自信",
@@ -53,6 +54,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "核心特色",
+      display: "grid",
       items: [
         {
           title: "基础场景实战闭环",
@@ -79,6 +81,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 身体与创伤",

--- a/content/programmes/research-academic/en/medical-research-essentials.ts
+++ b/content/programmes/research-academic/en/medical-research-essentials.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Research literacy programme for healthcare professionals",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/research.webp",
-    imageAlt: "Medical research and academic development",
+    image: "/images/courses/medical-research-essentials.webp",
+    imageAlt: "Medical Research Essentials Course",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "医学研究全流程解析",
@@ -61,6 +62,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Teaching Methods",
+      display: "timeline",
       items: [
         {
           title: "国际师资团队",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 医学研究导论：从理论到实践",

--- a/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "Master the international medical publication pipeline",
     ctaLabel: "Get Started Today",
     ctaHref: "/contact",
-    image: "/images/hero/research.webp",
-    imageAlt: "Medical research and academic development",
+    image: "/images/courses/medical-writing-publication-bootcamp.webp",
+    imageAlt: "Medical Writing & Publication Bootcamp",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Learning Objectives",
+      display: "list",
       items: [
         {
           title: "系统掌握国际医学出版全流程（SCI/SSCI/Medline 标准），包括论文评审机制与行业规范",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Key Features",
+      display: "grid",
       items: [
         {
           title: "系统性写作进阶框架",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "Curriculum",
+      display: "table",
       items: [
         {
           title: "1. 中国医生国际发表困境解析",

--- a/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
+++ b/content/programmes/research-academic/zh-CN/medical-research-essentials.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "医疗从业者科研素养提升课程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/research.webp",
-    imageAlt: "医学研究与学术发展",
+    image: "/images/courses/medical-research-essentials.webp",
+    imageAlt: "医学研究基础课程",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "医学研究全流程解析",
@@ -61,6 +62,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "教学方法",
+      display: "timeline",
       items: [
         {
           title: "国际师资团队",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 医学研究导论：从理论到实践",

--- a/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/zh-CN/medical-writing-publication-bootcamp.ts
@@ -18,8 +18,8 @@ const data: ProgrammeData = {
     lede: "系统掌握国际医学出版全流程",
     ctaLabel: "立即开始",
     ctaHref: "/contact",
-    image: "/images/hero/research.webp",
-    imageAlt: "医学研究与学术发展",
+    image: "/images/courses/medical-writing-publication-bootcamp.webp",
+    imageAlt: "医学写作与发表强化训练营",
   },
 
   sections: [
@@ -31,6 +31,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "学习目标",
+      display: "list",
       items: [
         {
           title: "系统掌握国际医学出版全流程（SCI/SSCI/Medline 标准），包括论文评审机制与行业规范",
@@ -57,6 +58,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "核心特色",
+      display: "grid",
       items: [
         {
           title: "系统性写作进阶框架",
@@ -87,6 +89,7 @@ const data: ProgrammeData = {
     {
       type: "value-props",
       title: "课程内容",
+      display: "table",
       items: [
         {
           title: "1. 中国医生国际发表困境解析",


### PR DESCRIPTION
## 背景

章逊 19:23 拍板：OET 作为详情页模板基线，其余 8 门 published 课程按 OET 完整套件落地。Moss 负责数据补齐（[ARCHITECTURE.md §0](https://github.com/theathondmanus/mediversity-web-v2/blob/main/docs/ARCHITECTURE.md) 领地分工）。

## 改动

给 8 门课所有 `value-props` section 加 `display` 字段（按 title 语义匹配）：

| section title | display |
|---|---|
| 学习目标 / Learning Objectives | `list` |
| 教学方法 / Teaching Methods | `timeline` |
| 核心特色 / Key Features | `grid` |
| 课程内容 / Curriculum | `table` |

⚠️ **不用 accordion**：按 [ARCHITECTURE.md §10 (2026-05-19 晚间)](https://github.com/theathondmanus/mediversity-web-v2/blob/main/docs/ARCHITECTURE.md) 决策，accordion 仅留给 FAQ。

## 涉及文件（16 个）

| 课程 | zh-CN + en |
|---|---|
| humanities/medical-humanities-and-communication-skills | ✅ |
| humanities/medical-humanities-and-general-practice-literacy | ✅ |
| medical-english/medical-english-for-doctors | ✅ |
| medical-english/medical-english-for-nurses | ✅ |
| medical-english/pre-departure-medical-english | ✅ |
| medical-english/preparatory-medical-english | ✅ |
| research-academic/medical-research-essentials | ✅ |
| research-academic/medical-writing-publication-bootcamp | ✅ |

## 关联

- 等 Manus PR：(a) OET 课程亮点 accordion → grid 修复 (b) 7 张新课程封面图
- Manus 图就位后，Moss 接力填 `cover` / `hero.image` 字段（另起一个 PR）

## 验证

- TypeScript: 本地 node_modules 缺失未跑，CI 会验
- 视觉影响：用户看到的每个 section 视觉形式将根据 display 字段切换

— Moss