### PR TITLE
fix(programmes): hub 卡 active courses 从 registry 动态算 + 删 future magic number

### DIFF
--- a/src/app/[locale]/programmes/page.tsx
+++ b/src/app/[locale]/programmes/page.tsx
@@ -18,6 +18,7 @@ import {
   FloatingShape,
   CornerAccent,
 } from "@/components/ui/section-decorations";
+import { getPublishedByCategory } from "../../../../content/programmes/registry";
 
 /* ── Animation presets ── */
 const fadeInUp = {
@@ -46,9 +47,8 @@ const PILLARS = [
     iconColor: "text-[#00438A]",
     accentColor: "#00438A",
     key: "medicalEnglish",
+    category: "medical-english",
     href: "/programmes/medical-english",
-    activeCourses: 5,
-    futureCourses: 11,
   },
   {
     icon: Microscope,
@@ -56,9 +56,8 @@ const PILLARS = [
     iconColor: "text-purple-700",
     accentColor: "#7e22ce",
     key: "research",
+    category: "research-academic",
     href: "/programmes/research-academic",
-    activeCourses: 2,
-    futureCourses: 7,
   },
   {
     icon: Stethoscope,
@@ -66,9 +65,8 @@ const PILLARS = [
     iconColor: "text-emerald-700",
     accentColor: "#047857",
     key: "observership",
+    category: "observership",
     href: "/programmes/observership",
-    activeCourses: 3,
-    futureCourses: 6,
   },
   {
     icon: BookOpen,
@@ -76,9 +74,8 @@ const PILLARS = [
     iconColor: "text-amber-700",
     accentColor: "#b45309",
     key: "humanities",
+    category: "humanities",
     href: "/programmes/humanities",
-    activeCourses: 1,
-    futureCourses: 5,
   },
 ];
 
@@ -298,25 +295,22 @@ export default function ProgrammesHubPage() {
                               {t(`pillars.${pillar.key}.desc`)}
                             </p>
 
-                            {/* Stats row */}
+                            {/* Stats row · 只显示在授课程数, 没有在授时显示标签 */}
                             <div className="flex items-center gap-6 mb-5">
-                              <div>
-                                <span className="text-2xl font-bold text-[#00438A]">
-                                  {pillar.activeCourses}
+                              {getPublishedByCategory(pillar.category).length > 0 ? (
+                                <div>
+                                  <span className="text-2xl font-bold text-[#00438A]">
+                                    {getPublishedByCategory(pillar.category).length}
+                                  </span>
+                                  <span className="text-xs text-[#8A889A] ml-1.5">
+                                    {t("activeCourses")}
+                                  </span>
+                                </div>
+                              ) : (
+                                <span className="inline-flex items-center gap-1.5 px-3 py-1 rounded-full bg-[#C4922A]/10 text-[#C4922A] text-xs font-medium">
+                                  {t("openingSoon")}
                                 </span>
-                                <span className="text-xs text-[#8A889A] ml-1.5">
-                                  {t("activeCourses")}
-                                </span>
-                              </div>
-                              <div className="w-px h-6 bg-[#E3E5EC]" />
-                              <div>
-                                <span className="text-2xl font-bold text-[#C4922A]/60">
-                                  {pillar.futureCourses}
-                                </span>
-                                <span className="text-xs text-[#8A889A] ml-1.5">
-                                  {t("futureCoursesShort")}
-                                </span>
-                              </div>
+                              )}
                             </div>
 
                             {/* CTA */}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -100,6 +100,7 @@
     "title": "Programmes",
     "subtitle": "Four pillars covering all core needs for healthcare professionals' international development",
     "activeCourses": "active courses",
+    "openingSoon": "Opening Soon",
     "explore": "Explore",
     "pillars": {
       "medicalEnglish": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -100,6 +100,7 @@
     "title": "培训项目",
     "subtitle": "四大板块覆盖医疗专业人士国际化发展的全部核心需求",
     "activeCourses": "门在授课程",
+    "openingSoon": "即将开放",
     "explore": "了解更多",
     "pillars": {
       "medicalEnglish": {


### PR DESCRIPTION
## 章逊原话
> 这个只有两门 ...（humanities pillar 卡显示"1 门在授课程"）
> 目前应该没有在授课程（指 observership 显示 3 门是假的）

## Bug 现象

`/programmes` hub 4 张卡显示的「门在授课程」和「门规划中」数字是 hardcoded magic number, 跟 registry 真实数据脱节:

| pillar | 之前显示 | registry 实际 published | 之前 future 显示 |
|---|---|---|---|
| medical-english | 5 | 5 ✅ | 11（凭空） |
| research-academic | 2 | 2 ✅ | 7（凭空） |
| **observership** | **3 ❌** | **0** | 6（凭空） |
| **humanities** | **1 ❌** | **2** | 5（凭空） |

## 修复

1. `PILLARS` 数组添加 `category` 字段, 删除硬编码 `activeCourses`/`futureCourses`
2. 渲染时调用 `getPublishedByCategory(category).length` 动态算
3. **彻底砍掉「门规划中」badge**（章逊回方案 1: registry 没 future entry, 别瞎显示）
4. 0 published 时显示「即将开放/Opening Soon」标签（observership 用）
5. 新增 `programmesHub.openingSoon` i18n key (zh + en 对称)

## 修复后

- medical-english: 5 ✅
- research-academic: 2 ✅
- humanities: 2 ✅ (之前显示 1)
- observership: 「即将开放」标签 ✅ (之前显示 3 门, 实际 0)

— Moss