### PR TITLE
fix(i18n): pillar 课程卡 description 走 messages (#109 漏)

### DIFF
--- a/src/app/[locale]/programmes/humanities/page.tsx
+++ b/src/app/[locale]/programmes/humanities/page.tsx
@@ -10,8 +10,8 @@ const subcategories: SubCategory[] = [
     titleKey: "medicalHumanities",
     descKey: "medicalHumanitiesDesc",
     courses: [
-      { titleKey: "medicalHumanitiesGeneralPractice", status: "active", slug: "medical-humanities-and-general-practice-literacy", cover: "/images/courses/medical-humanities-and-general-practice-literacy.webp", coverAlt: "医学人文与全科素养", description: "10 节课系统培养医学人文素养与全科执业能力，融合伦理思辨与临床实践" },
-      { titleKey: "medicalHumanitiesCommunicationSkills", status: "active", slug: "medical-humanities-and-communication-skills", cover: "/images/courses/medical-humanities-and-communication-skills.webp", coverAlt: "医学人文与沟通技能", description: "6 节课提升医患沟通能力与人文关怀实践，培养共情与叙事医学思维" },
+      { titleKey: "medicalHumanitiesGeneralPractice", status: "active", slug: "medical-humanities-and-general-practice-literacy", cover: "/images/courses/medical-humanities-and-general-practice-literacy.webp", coverAlt: "医学人文与全科素养", descriptionKey: "medical-humanities-and-general-practice-literacy" },
+      { titleKey: "medicalHumanitiesCommunicationSkills", status: "active", slug: "medical-humanities-and-communication-skills", cover: "/images/courses/medical-humanities-and-communication-skills.webp", coverAlt: "医学人文与沟通技能", descriptionKey: "medical-humanities-and-communication-skills" },
       { titleKey: "empathyPatientCommunication", status: "future" },
       { titleKey: "narrativeMedicine", status: "future" },
     ],

--- a/src/app/[locale]/programmes/medical-english/page.tsx
+++ b/src/app/[locale]/programmes/medical-english/page.tsx
@@ -10,7 +10,7 @@ const subcategories: SubCategory[] = [
     titleKey: "foundations",
     descKey: "foundationsDesc",
     courses: [
-      { titleKey: "preparatoryMedicalEnglish", status: "active", slug: "preparatory-medical-english", cover: "/images/courses/preparatory-medical-english.webp", description: "12 课时基础英语课程，专为医疗从业者设计" },
+      { titleKey: "preparatoryMedicalEnglish", status: "active", slug: "preparatory-medical-english", cover: "/images/courses/preparatory-medical-english.webp", descriptionKey: "preparatory-medical-english" },
       { titleKey: "clinicalCommunicationFoundations", status: "future" },
       { titleKey: "generalEnglishHealthcare", status: "future" },
     ],
@@ -21,7 +21,7 @@ const subcategories: SubCategory[] = [
     titleKey: "oet",
     descKey: "oetDesc",
     courses: [
-      { titleKey: "oetPreparation", status: "active", slug: "oet-preparation", cover: "/images/courses/oet-preparation.webp", description: "提升您的医学英语能力，助力成功通过 OET 考试" },
+      { titleKey: "oetPreparation", status: "active", slug: "oet-preparation", cover: "/images/courses/oet-preparation.webp", descriptionKey: "oet-preparation" },
       { titleKey: "oetIntensiveBootcamp", status: "future" },
       { titleKey: "platCommunication", status: "future" },
       { titleKey: "healthcareInterview", status: "future" },
@@ -34,8 +34,8 @@ const subcategories: SubCategory[] = [
     descKey: "clinicalDesc",
     courses: [
       { titleKey: "workplaceMedicalEnglish", status: "future" },
-      { titleKey: "medicalEnglishDoctors", status: "active", slug: "medical-english-for-doctors", cover: "/images/courses/medical-english-for-doctors.webp", description: "医疗专业人员语言沟通能力提升课程" },
-      { titleKey: "medicalEnglishNurses", status: "active", slug: "medical-english-for-nurses", cover: "/images/courses/medical-english-for-nurses.webp", description: "护士专属医学英语沟通能力提升课程" },
+      { titleKey: "medicalEnglishDoctors", status: "active", slug: "medical-english-for-doctors", cover: "/images/courses/medical-english-for-doctors.webp", descriptionKey: "medical-english-for-doctors" },
+      { titleKey: "medicalEnglishNurses", status: "active", slug: "medical-english-for-nurses", cover: "/images/courses/medical-english-for-nurses.webp", descriptionKey: "medical-english-for-nurses" },
       { titleKey: "clinicalConsultationEnglish", status: "future" },
       { titleKey: "wardHandoverCommunication", status: "future" },
     ],
@@ -46,7 +46,7 @@ const subcategories: SubCategory[] = [
     titleKey: "globalMobility",
     descKey: "globalMobilityDesc",
     courses: [
-      { titleKey: "preDepartureMedicalEnglish", status: "active", slug: "pre-departure-medical-english", cover: "/images/courses/pre-departure-medical-english.webp", description: "12 周强化语言项目，专为即将海外临床实习的医疗专业人士打造" },
+      { titleKey: "preDepartureMedicalEnglish", status: "active", slug: "pre-departure-medical-english", cover: "/images/courses/pre-departure-medical-english.webp", descriptionKey: "pre-departure-medical-english" },
       { titleKey: "ukHealthcareOrientation", status: "future" },
       { titleKey: "culturalCommunication", status: "future" },
       { titleKey: "internationalWorkplaceReadiness", status: "future" },

--- a/src/app/[locale]/programmes/research-academic/page.tsx
+++ b/src/app/[locale]/programmes/research-academic/page.tsx
@@ -10,7 +10,7 @@ const subcategories: SubCategory[] = [
     titleKey: "researchTraining",
     descKey: "researchTrainingDesc",
     courses: [
-      { titleKey: "medicalResearchEssentials", status: "active", slug: "medical-research-essentials", cover: "/images/courses/medical-research-essentials.webp", coverAlt: "医学研究基础", description: "6 周系统学习医学研究方法与循证医学，培养临床研究思维与文献分析能力" },
+      { titleKey: "medicalResearchEssentials", status: "active", slug: "medical-research-essentials", cover: "/images/courses/medical-research-essentials.webp", coverAlt: "医学研究基础", descriptionKey: "medical-research-essentials" },
       { titleKey: "researchMethodology", status: "future" },
       { titleKey: "evidenceBasedMedicine", status: "future" },
     ],
@@ -21,7 +21,7 @@ const subcategories: SubCategory[] = [
     titleKey: "academicWriting",
     descKey: "academicWritingDesc",
     courses: [
-      { titleKey: "medicalWritingBootcamp", status: "active", slug: "medical-writing-publication-bootcamp", cover: "/images/courses/medical-writing-publication-bootcamp.webp", coverAlt: "医学写作与发表集训营", description: "12 小时集中训练 SCI 论文写作与国际发表技巧，从选题到投稿全流程覆盖" },
+      { titleKey: "medicalWritingBootcamp", status: "active", slug: "medical-writing-publication-bootcamp", cover: "/images/courses/medical-writing-publication-bootcamp.webp", coverAlt: "医学写作与发表集训营", descriptionKey: "medical-writing-publication-bootcamp" },
       { titleKey: "sciWritingSupport", status: "future" },
       { titleKey: "academicPresentationSkills", status: "future" },
     ],

--- a/src/components/programmes/PillarLandingPage.tsx
+++ b/src/components/programmes/PillarLandingPage.tsx
@@ -24,6 +24,8 @@ export interface CourseItem {
   coverAlt?: string;
   /** Short description for the card */
   description?: string;
+  /** i18n key for short description (under courseDescriptions namespace) */
+  descriptionKey?: string;
 }
 
 export interface SubCategory {
@@ -78,6 +80,7 @@ export default function PillarLandingPage({
 }: PillarLandingPageProps) {
   const t = useTranslations(`programmes.${pillarKey}`);
   const tCommon = useTranslations("common");
+  const tDesc = useTranslations("courseDescriptions");
 
   const activeCourses = subcategories.flatMap((sub) =>
     sub.courses.filter((c) => c.status === "active"),
@@ -225,9 +228,9 @@ export default function PillarLandingPage({
                             <h3 className="font-semibold text-[#0A1628] mb-2 leading-snug text-lg">
                               {t(`courses.${course.titleKey}`)}
                             </h3>
-                            {course.description && (
+                            {(course.descriptionKey || course.description) && (
                               <p className="text-sm text-[#3C3A47] leading-relaxed mb-4 line-clamp-2">
-                                {course.description}
+                                {course.descriptionKey ? tDesc(course.descriptionKey) : course.description}
                               </p>
                             )}
                             <div className="mt-auto pt-3">

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -496,5 +496,16 @@
     "servicesEyebrow": "SERVICES",
     "aboutEyebrow": "ABOUT",
     "insightsEyebrow": "INSIGHTS"
+  },
+  "courseDescriptions": {
+    "preparatory-medical-english": "12-lesson foundation English programme designed for healthcare professionals",
+    "oet-preparation": "Strengthen your medical English to confidently pass the OET examination",
+    "medical-english-for-doctors": "Professional English communication training for clinicians",
+    "medical-english-for-nurses": "Medical English communication training tailored for nurses",
+    "pre-departure-medical-english": "12-week intensive language programme for healthcare professionals preparing for overseas clinical placements",
+    "medical-research-essentials": "A 6-week systematic introduction to medical research methodology and evidence-based medicine, building clinical research thinking and literature analysis skills",
+    "medical-writing-publication-bootcamp": "A 12-hour intensive on SCI paper writing and international publication skills — covering the full pipeline from topic selection to submission",
+    "medical-humanities-and-general-practice-literacy": "10 sessions developing medical humanities literacy and general practice competence, integrating ethical reasoning with clinical practice",
+    "medical-humanities-and-communication-skills": "6 sessions building patient-doctor communication and humanistic care practice, fostering empathy and narrative medicine thinking"
   }
 }

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -496,5 +496,16 @@
     "servicesEyebrow": "服务",
     "aboutEyebrow": "关于我们",
     "insightsEyebrow": "洞察"
+  },
+  "courseDescriptions": {
+    "preparatory-medical-english": "12 课时基础英语课程，专为医疗从业者设计",
+    "oet-preparation": "提升您的医学英语能力，助力成功通过 OET 考试",
+    "medical-english-for-doctors": "医疗专业人员语言沟通能力提升课程",
+    "medical-english-for-nurses": "护士专属医学英语沟通能力提升课程",
+    "pre-departure-medical-english": "12 周强化语言项目，专为即将海外临床实习的医疗专业人士打造",
+    "medical-research-essentials": "6 周系统学习医学研究方法与循证医学，培养临床研究思维与文献分析能力",
+    "medical-writing-publication-bootcamp": "12 小时集中训练 SCI 论文写作与国际发表技巧，从选题到投稿全流程覆盖",
+    "medical-humanities-and-general-practice-literacy": "10 节课系统培养医学人文素养与全科执业能力，融合伦理思辨与临床实践",
+    "medical-humanities-and-communication-skills": "6 节课提升医患沟通能力与人文关怀实践，培养共情与叙事医学思维"
   }
 }


### PR DESCRIPTION
巡视 5/21 第二轮发现 en pillar 卡片 description 仍是中文。截图：'12 课时基础英语课程，专为医疗从业者设计' 出现在 /en 页面。

#109 漏掉的最后一类硬编码。修法见 commit msg。tsc 通过，9 处 zh/en 对称。