### PR TITLE
fix(i18n): 7 门 en 课程文件批量翻译 (#109 后续)

### DIFF
--- a/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-communication-skills.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "本课程旨在帮助医疗从业者掌握核心沟通技巧与人文素养，提供以患者为中心的医疗服务。除专业知 识外，课程聚焦共情能力、医学伦理、患者心理、跨文化意识及医患关系管理。学员将通过沉浸式实 践活动，掌握更具温度、专业性与适应性的沟通技巧，从而在复杂临床场景中实现高效共情与精准决策。",
+      body: "This programme equips healthcare professionals with the core communication skills and humanistic literacy needed to deliver patient-centred care. Alongside clinical knowledge, it focuses on empathy, medical ethics, patient psychology, cross-cultural awareness and the management of the doctor-patient relationship. Through immersive practice, participants develop communication that is more empathetic, professional and adaptive — enabling effective empathy and precise decision-making within complex clinical scenarios.",
     },
     {
       type: "value-props",
@@ -34,23 +34,23 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "培养人文价值观与以患者为中心的思维模式",
+          title: "Develop humanistic values and a patient-centred mindset",
           description: "",
         },
         {
-          title: "通过高效医患沟通建立信任",
+          title: "Build trust through effective patient-doctor communication",
           description: "",
         },
         {
-          title: "运用跨文化技能服务多元患者群体",
+          title: "Apply cross-cultural skills to serve diverse patient populations",
           description: "",
         },
         {
-          title: "在临床实践中强化同理心与情商",
+          title: "Strengthen empathy and emotional intelligence in clinical practice",
           description: "",
         },
         {
-          title: "运用医学伦理进行共情与伦理决策",
+          title: "Apply medical ethics for empathetic and ethical decision-making",
           description: "",
         },
       ],
@@ -61,19 +61,19 @@ const data: ProgrammeData = {
       display: "timeline",
       items: [
         {
-          title: "高仿真案例教学",
+          title: "High-fidelity case-based teaching",
           description: "",
         },
         {
-          title: "角色扮演模拟训练",
+          title: "Role-play simulation training",
           description: "",
         },
         {
-          title: "互动式深度对话",
+          title: "Interactive in-depth dialogue",
           description: "",
         },
         {
-          title: "结构化实践任务",
+          title: "Structured practical tasks",
           description: "",
         },
       ],
@@ -84,28 +84,28 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 医学人文与职业身份认同",
-          description: "1. 医学人文与职业身份认同",
+          title: "1. Medical humanities and professional identity",
+          description: "1. Medical humanities and professional identity",
         },
         {
-          title: "2. 医患沟通技巧",
-          description: "2. 医患沟通技巧",
+          title: "2. Patient-doctor communication skills",
+          description: "2. Patient-doctor communication skills",
         },
         {
-          title: "3. 患者心理与情绪支持",
-          description: "3. 患者心理与情绪支持",
+          title: "3. Patient psychology and emotional support",
+          description: "3. Patient psychology and emotional support",
         },
         {
-          title: "4. 医学伦理与共情照护",
-          description: "4. 医学伦理与共情照护",
+          title: "4. Medical ethics and empathetic care",
+          description: "4. Medical ethics and empathetic care",
         },
         {
-          title: "5. 跨文化沟通",
-          description: "5. 跨文化沟通",
+          title: "5. Cross-cultural communication",
+          description: "5. Cross-cultural communication",
         },
         {
-          title: "6. 医疗从业者的身心健康",
-          description: "6. 医疗从业者的身心健康",
+          title: "6. Wellbeing for healthcare professionals",
+          description: "6. Wellbeing for healthcare professionals",
         },
       ],
     },

--- a/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
+++ b/content/programmes/humanities/en/medical-humanities-and-general-practice-literacy.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "本课程旨在为医学生和医疗从业者提供医学人文知识、全科医学思维及实用沟通技能。通过真实案例 研讨、高仿真情景模拟及跨学科协作训练，学员将系统掌握以患者为中心的诊疗思维模式，提升伦理 敏感度与沟通效能。课程聚焦全球医疗体系中的全科医学角色，结合国际前沿经验与中国基层医疗实 际需求，培养学员在复杂医疗场景下的临床推理能力、跨学科协作意识及职业韧性，助力其成为兼具 技术精湛与人文温度的复合型医疗人才。",
+      body: "This programme builds the medical humanities knowledge, general-practice clinical thinking and practical communication skills needed by medical students and healthcare professionals. Through real-world case discussions, high-fidelity scenario simulations and interdisciplinary collaborative training, participants develop a patient-centred approach to care, alongside greater ethical awareness and communication effectiveness. With a focus on the role of general practice within global healthcare systems, the programme integrates leading international experience with the realities of frontline care in China — building clinical reasoning, interdisciplinary collaboration and professional resilience for complex healthcare settings, supporting learners to become well-rounded clinicians combining technical excellence with humanistic care.",
     },
     {
       type: "value-props",
@@ -34,27 +34,27 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "通过医学人文核心理念培养人文关怀",
+          title: "Build humanistic care through the core principles of medical humanities",
           description: "",
         },
         {
-          title: "在临床决策中应用医学伦理",
+          title: "Apply medical ethics to clinical decision-making",
           description: "",
         },
         {
-          title: "提升医患沟通以增强信任与服务质量",
+          title: "Strengthen patient-doctor communication to build trust and improve quality of care",
           description: "",
         },
         {
-          title: "理解全科医学在医疗体系中的原则与作用",
+          title: "Understand the principles and role of general practice within healthcare systems",
           description: "",
         },
         {
-          title: "培养跨学科临床思维",
+          title: "Develop interdisciplinary clinical thinking",
           description: "",
         },
         {
-          title: "通过案例与实践强化临床推理与应变能力",
+          title: "Strengthen clinical reasoning and adaptability through cases and applied practice",
           description: "",
         },
       ],
@@ -65,23 +65,23 @@ const data: ProgrammeData = {
       display: "timeline",
       items: [
         {
-          title: "案例分析",
+          title: "Case analysis",
           description: "",
         },
         {
-          title: "情景模拟",
+          title: "Scenario simulation",
           description: "",
         },
         {
-          title: "跨学科阅读",
+          title: "Interdisciplinary reading",
           description: "",
         },
         {
-          title: "实践练习",
+          title: "Applied practice",
           description: "",
         },
         {
-          title: "小组讨论",
+          title: "Group discussion",
           description: "",
         },
       ],
@@ -92,44 +92,44 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 医学人文导论：医学不仅是科学，更是人文",
-          description: "1. 医学人文导论：医学不仅是科学，更是人文",
+          title: "1. Introduction to medical humanities: medicine as both science and humanity",
+          description: "1. Introduction to medical humanities: medicine as both science and humanity",
         },
         {
-          title: "2. 医学伦理与临床决策：伦理挑战与价值判断",
-          description: "2. 医学伦理与临床决策：伦理挑战与价值判断",
+          title: "2. Medical ethics and clinical decision-making: ethical challenges and value judgement",
+          description: "2. Medical ethics and clinical decision-making: ethical challenges and value judgement",
         },
         {
-          title: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
-          description: "3. 医患沟通与同理心训练：建立信任与提升患者体验",
+          title: "3. Patient-doctor communication and empathy: building trust and improving patient experience",
+          description: "3. Patient-doctor communication and empathy: building trust and improving patient experience",
         },
         {
-          title: "4. 全科医学的基础与全球视角：全科医生的核心能力",
-          description: "4. 全科医学的基础与全球视角：全科医生的核心能力",
+          title: "4. The foundations and global perspective of general practice: the core competencies of GPs",
+          description: "4. The foundations and global perspective of general practice: the core competencies of GPs",
         },
         {
-          title: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
-          description: "5. 跨学科视角下的医学：文学、哲学、历史与医学",
+          title: "5. Medicine through interdisciplinary lenses: literature, philosophy, history and medicine",
+          description: "5. Medicine through interdisciplinary lenses: literature, philosophy, history and medicine",
         },
         {
-          title: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
-          description: "6. 医疗从业者的心理韧性：如何应对压力与职业倦怠？",
+          title: "6. Psychological resilience for healthcare professionals: managing stress and burnout",
+          description: "6. Psychological resilience for healthcare professionals: managing stress and burnout",
         },
         {
-          title: "7. 全科医学临床实践：初步诊断与综合评估",
-          description: "7. 全科医学临床实践：初步诊断与综合评估",
+          title: "7. Clinical practice in general medicine: initial diagnosis and comprehensive assessment",
+          description: "7. Clinical practice in general medicine: initial diagnosis and comprehensive assessment",
         },
         {
-          title: "8. 特殊人群的医疗照护：提供个体化服务",
-          description: "8. 特殊人群的医疗照护：提供个体化服务",
+          title: "8. Care for special populations: delivering individualised services",
+          description: "8. Care for special populations: delivering individualised services",
         },
         {
-          title: "9. 全科医学见习：亲身体验基层医疗",
-          description: "9. 全科医学见习：亲身体验基层医疗",
+          title: "9. General practice observership: first-hand experience of primary care",
+          description: "9. General practice observership: first-hand experience of primary care",
         },
         {
-          title: "10. 总结与实践应用：案例研究与职业发展规划",
-          description: "10. 总结与实践应用：案例研究与职业发展规划",
+          title: "10. Synthesis and applied practice: case studies and career development planning",
+          description: "10. Synthesis and applied practice: case studies and career development planning",
         },
       ],
     },

--- a/content/programmes/medical-english/en/medical-english-for-doctors.ts
+++ b/content/programmes/medical-english/en/medical-english-for-doctors.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "以职业英语考试（OET）为基础，课程重点关注真实医疗情境，培养医生自信沟通能力和跨文化意识， 助力提供优质医疗服务。参与者将学会与患者有效互动、与多学科团队协作、管理专业通信， 并对全球医学研究做出贡献。",
+      body: "Built on the framework of the Occupational English Test (OET), this programme focuses on real clinical scenarios to develop doctors' confident communication and cross-cultural awareness, supporting the delivery of high-quality care. Participants will learn to engage effectively with patients, collaborate within multidisciplinary teams, manage professional correspondence, and contribute to international medical research.",
     },
     {
       type: "value-props",
@@ -34,23 +34,23 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "掌握医学术语：熟练运用专业医学词汇，确保精准的医患沟通",
+          title: "Master medical terminology: confident use of specialist vocabulary for precise doctor-patient communication",
           description: "",
         },
         {
-          title: "提升临床互动：具备提问、描述、指导的能力，开展高效的医患交流",
+          title: "Strengthen clinical interaction: the ability to ask, describe and instruct for effective patient encounters",
           description: "",
         },
         {
-          title: "改善患者咨询：掌握访谈技巧，倾听患者需求，提供专业医疗建议",
+          title: "Improve patient consultations: interview skills that listen to patient needs and deliver professional medical advice",
           description: "",
         },
         {
-          title: "加强文档报告：准确撰写医学报告，规范记录患者信息",
+          title: "Enhance clinical documentation: produce accurate medical reports and well-structured patient records",
           description: "",
         },
         {
-          title: "连接全球医疗：参与国际研究合作，为医学发展贡献力量",
+          title: "Connect with global healthcare: participate in international research collaboration and contribute to medical advancement",
           description: "",
         },
       ],
@@ -61,31 +61,31 @@ const data: ProgrammeData = {
       display: "timeline",
       items: [
         {
-          title: "互动教学与合作学习",
+          title: "Interactive teaching and collaborative learning",
           description: "",
         },
         {
-          title: "角色扮演、模拟、案例分析",
+          title: "Role-play, simulation and case analysis",
           description: "",
         },
         {
-          title: "OET 考试导向练习",
+          title: "OET exam-oriented practice",
           description: "",
         },
         {
-          title: "小组讨论、同行反馈",
+          title: "Group discussion and peer feedback",
           description: "",
         },
         {
-          title: "多媒体辅助教学",
+          title: "Multimedia-assisted teaching",
           description: "",
         },
         {
-          title: "社区互动支持",
+          title: "Learning community support",
           description: "",
         },
         {
-          title: "导师指导",
+          title: "Individual mentor guidance",
           description: "",
         },
       ],
@@ -96,27 +96,27 @@ const data: ProgrammeData = {
       display: "grid",
       items: [
         {
-          title: "全面定制化学习路径",
+          title: "Fully customised learning pathway",
           description: "",
         },
         {
-          title: "融入国际标准",
+          title: "Aligned with international standards",
           description: "",
         },
         {
-          title: "互动支持式学习",
+          title: "Interactive and supportive learning",
           description: "",
         },
         {
-          title: "文化敏感沟通",
+          title: "Culturally sensitive communication",
           description: "",
         },
         {
-          title: "实用专业导向",
+          title: "Practical and profession-oriented",
           description: "",
         },
         {
-          title: "持续跟踪进步",
+          title: "Ongoing progress tracking",
           description: "",
         },
       ],
@@ -127,60 +127,60 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "基础知识",
-          description: "基础知识",
+          title: "Foundations",
+          description: "Foundations",
         },
         {
-          title: "医学与辅助医学人员与场所",
-          description: "医学与辅助医学人员与场所",
+          title: "Medical and allied health professionals and settings",
+          description: "Medical and allied health professionals and settings",
         },
         {
-          title: "教育与培训",
-          description: "教育与培训",
+          title: "Education and training",
+          description: "Education and training",
         },
         {
-          title: "系统、疾病与症状（20 个子模块）",
-          description: "系统、疾病与症状（20 个子模块）",
+          title: "Systems, diseases and symptoms (20 sub-modules)",
+          description: "Systems, diseases and symptoms (20 sub-modules)",
         },
         {
-          title: "检查",
-          description: "检查",
+          title: "Investigations",
+          description: "Investigations",
         },
         {
-          title: "治疗",
-          description: "治疗",
+          title: "Treatment",
+          description: "Treatment",
         },
         {
-          title: "预防",
-          description: "预防",
+          title: "Prevention",
+          description: "Prevention",
         },
         {
-          title: "流行病学",
-          description: "流行病学",
+          title: "Epidemiology",
+          description: "Epidemiology",
         },
         {
-          title: "伦理学",
-          description: "伦理学",
+          title: "Ethics",
+          description: "Ethics",
         },
         {
-          title: "研究",
-          description: "研究",
+          title: "Research",
+          description: "Research",
         },
         {
-          title: "采集病史",
-          description: "采集病史",
+          title: "History taking",
+          description: "History taking",
         },
         {
-          title: "检查（临床）",
-          description: "检查（临床）",
+          title: "Examination (clinical)",
+          description: "Examination (clinical)",
         },
         {
-          title: "解释",
-          description: "解释",
+          title: "Explanation",
+          description: "Explanation",
         },
         {
-          title: "展示",
-          description: "展示",
+          title: "Presentation",
+          description: "Presentation",
         },
       ],
     },

--- a/content/programmes/medical-english/en/medical-english-for-nurses.ts
+++ b/content/programmes/medical-english/en/medical-english-for-nurses.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "护士医学英语课程是一门专为护士设计的专业课程，旨在提升其在英语医疗环境中有效进行患者护理 和协作所需的沟通技巧和医学词汇。该课程围绕职业英语测试（OET）结构，为护士提供日常与患者、 同事及其他医疗专业人士互动所需的实用语言技能。课程精心策划，帮助护士增强专业能力，自信应 对医疗场景，提升职业表现。",
+      body: "Medical English for Nurses is a specialist programme designed to develop the communication skills and clinical vocabulary nurses need to deliver safe, collaborative patient care in English-speaking healthcare environments. Structured around the Occupational English Test (OET), it equips nurses with practical language for everyday interactions with patients, colleagues and other healthcare professionals — building professional confidence, clinical clarity, and stronger performance in international care settings.",
     },
     {
       type: "value-props",
@@ -34,23 +34,23 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "医学术语发展：全面掌握医学术语及其在临床中的应用",
+          title: "Develop medical terminology: comprehensive command of clinical vocabulary and its application in practice",
           description: "",
         },
         {
-          title: "提升临床沟通技能：通过职业英语测试（OET）材料提高护理场景中的听、说、读、写能力",
+          title: "Strengthen clinical communication: improve listening, speaking, reading and writing in nursing scenarios using OET-aligned materials",
           description: "",
         },
         {
-          title: "改善患者沟通：在患者评估、健康检查和紧急情况下促进有效沟通",
+          title: "Improve patient communication: support effective interaction during assessments, health checks and emergency situations",
           description: "",
         },
         {
-          title: "增强患者护理中的能力与同理心：培养准确且富有同理心的患者教育和治疗信息传达能力",
+          title: "Build capability and empathy in patient care: deliver accurate and empathetic patient education and treatment information",
           description: "",
         },
         {
-          title: "强化文档与报告能力：掌握医疗环境中所需的高级英语结构，以实现清晰的文档与报告",
+          title: "Enhance documentation and reporting: master the advanced English structures needed for clear clinical notes and handover",
           description: "",
         },
       ],
@@ -61,31 +61,31 @@ const data: ProgrammeData = {
       display: "timeline",
       items: [
         {
-          title: "互动与协作学习",
+          title: "Interactive and collaborative learning",
           description: "",
         },
         {
-          title: "角色扮演、模拟与案例分析",
+          title: "Role-play, simulation and case analysis",
           description: "",
         },
         {
-          title: "基于 OET 的结构化练习",
+          title: "Structured OET-based practice",
           description: "",
         },
         {
-          title: "小组讨论与互评",
+          title: "Group discussion and peer review",
           description: "",
         },
         {
-          title: "多媒体资料",
+          title: "Multimedia learning materials",
           description: "",
         },
         {
-          title: "社区支持",
+          title: "Learning community support",
           description: "",
         },
         {
-          title: "辅导与指导",
+          title: "Mentoring and guidance",
           description: "",
         },
       ],
@@ -96,27 +96,27 @@ const data: ProgrammeData = {
       display: "grid",
       items: [
         {
-          title: "全面且个性化的学习路径",
+          title: "Comprehensive and personalised learning pathway",
           description: "",
         },
         {
-          title: "国际认可标准的整合",
+          title: "Integration of internationally recognised standards",
           description: "",
         },
         {
-          title: "互动学习与支持性环境",
+          title: "Interactive learning in a supportive environment",
           description: "",
         },
         {
-          title: "文化敏感与有效沟通",
+          title: "Culturally sensitive, effective communication",
           description: "",
         },
         {
-          title: "实用、相关且专业导向",
+          title: "Practical, relevant and profession-oriented",
           description: "",
         },
         {
-          title: "持续进步跟踪",
+          title: "Ongoing progress tracking",
           description: "",
         },
       ],
@@ -127,52 +127,52 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "基础知识",
-          description: "基础知识",
+          title: "Foundations",
+          description: "Foundations",
         },
         {
-          title: "医学与辅助医学人员与场所",
-          description: "医学与辅助医学人员与场所",
+          title: "Medical and allied health professionals and settings",
+          description: "Medical and allied health professionals and settings",
         },
         {
-          title: "教育与培训",
-          description: "教育与培训",
+          title: "Education and training",
+          description: "Education and training",
         },
         {
-          title: "系统、疾病与症状（20 个子模块）",
-          description: "系统、疾病与症状（20 个子模块）",
+          title: "Systems, diseases and symptoms (20 sub-modules)",
+          description: "Systems, diseases and symptoms (20 sub-modules)",
         },
         {
-          title: "检查",
-          description: "检查",
+          title: "Investigations",
+          description: "Investigations",
         },
         {
-          title: "治疗",
-          description: "治疗",
+          title: "Treatment",
+          description: "Treatment",
         },
         {
-          title: "预防",
-          description: "预防",
+          title: "Prevention",
+          description: "Prevention",
         },
         {
-          title: "流行病学",
-          description: "流行病学",
+          title: "Epidemiology",
+          description: "Epidemiology",
         },
         {
-          title: "伦理学",
-          description: "伦理学",
+          title: "Ethics",
+          description: "Ethics",
         },
         {
-          title: "采集病史",
-          description: "采集病史",
+          title: "History taking",
+          description: "History taking",
         },
         {
-          title: "检查（临床）",
-          description: "检查（临床）",
+          title: "Examination (clinical)",
+          description: "Examination (clinical)",
         },
         {
-          title: "解释",
-          description: "解释",
+          title: "Explanation",
+          description: "Explanation",
         },
       ],
     },

--- a/content/programmes/medical-english/en/pre-departure-medical-english.ts
+++ b/content/programmes/medical-english/en/pre-departure-medical-english.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "课程旨在帮助学员掌握在国际医疗环境中所需的沟通技巧和文化敏感度，提升他们在不同医疗场景中 的自信表现。通过实际操作与理论结合，学员将学会在多文化背景下高效地与患者、同事及其他医疗 团队成员进行交流。",
+      body: "This programme equips learners with the communication skills and cultural sensitivity needed to perform confidently in international healthcare settings. Combining practice with theory, learners build the ability to interact effectively with patients, colleagues and other members of the clinical team across diverse cultural contexts.",
     },
     {
       type: "value-props",
@@ -34,16 +34,16 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "真实情境模拟",
-          description: "本课程将实际医疗场景引入课堂，确保学员可以身临其境地体验跨文化沟通的挑战和解决方案",
+          title: "Real-world clinical simulation",
+          description: "Brings authentic medical scenarios into the classroom so learners experience the challenges — and solutions — of cross-cultural communication first-hand",
         },
         {
-          title: "以患者为中心的沟通框架",
-          description: "学员将学习并应用剑桥-卡尔加里指南，优化对患者咨询服务，确保信息清晰传达并展现同理心",
+          title: "Patient-centred communication framework",
+          description: "Learners apply the Cambridge-Calgary Guide to structure patient consultations, ensuring clear information delivery with empathy",
         },
         {
-          title: "多元化学习体验",
-          description: "课程结合互动讨论、实践操作和自学任务，提供全方位的学习路径",
+          title: "A multi-modal learning experience",
+          description: "Interactive discussion, hands-on practice and independent study combine to deliver a well-rounded learning pathway",
         },
       ],
     },
@@ -53,44 +53,44 @@ const data: ProgrammeData = {
       display: "grid",
       items: [
         {
-          title: "教学策略可根据您的需求量身定制",
+          title: "Teaching strategies tailored to your needs",
           description: "",
         },
         {
-          title: "融合全球公认标准",
+          title: "Built on internationally recognised standards",
           description: "",
         },
         {
-          title: "互动学习与实时指导",
+          title: "Interactive learning with real-time guidance",
           description: "",
         },
         {
-          title: "实用且有效的沟通技能",
+          title: "Practical and effective communication skills",
           description: "",
         },
         {
-          title: "专注于职业发展",
+          title: "Focus on professional development",
           description: "",
         },
         {
-          title: "专业师资力量",
-          description: "由经验丰富的英语外教团队授课，确保学员获得高质量、针对性的语言指导",
+          title: "Experienced specialist teaching team",
+          description: "Delivered by an experienced team of international English tutors, ensuring high-quality, targeted language instruction",
         },
         {
-          title: "互动讨论与角色扮演",
-          description: "通过小组互动和模拟实际场景，学员将体验不同角色，并在模拟中提高沟通技巧",
+          title: "Interactive discussion and role-play",
+          description: "Through small-group activities and scenario-based simulations, learners take on different clinical roles and develop their communication skills",
         },
         {
-          title: "文化敏感度训练",
-          description: "专门设计的课程内容帮助学员理解和应对不同文化背景下的患者需求和行为反应",
+          title: "Cultural sensitivity training",
+          description: "Course content is purpose-built to help learners understand and respond to patient needs and behaviours across different cultural backgrounds",
         },
         {
-          title: "个性化反馈与指导",
-          description: "学员将在每个关键阶段获得专属的个性化反馈和建议，以不断提升其语言和沟通技巧",
+          title: "Personalised feedback and guidance",
+          description: "Learners receive individual feedback and recommendations at every key stage to continually strengthen their language and communication skills",
         },
         {
-          title: "在线资源支持",
-          description: "学员可随时访问丰富的在线学习资源，包括视频教程、医学案例和词汇练习，灵活安排学习进度",
+          title: "Online learning resources",
+          description: "Learners have on-demand access to a rich library of online materials — including video tutorials, clinical case studies and vocabulary practice — to support flexible learning",
         },
       ],
     },
@@ -100,52 +100,52 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 在不同医疗场景下自我介绍",
-          description: "1. 在不同医疗场景下自我介绍",
+          title: "1. Introducing yourself across different clinical settings",
+          description: "1. Introducing yourself across different clinical settings",
         },
         {
-          title: "2. 医患关系建立",
-          description: "2. 医患关系建立",
+          title: "2. Building the doctor-patient relationship",
+          description: "2. Building the doctor-patient relationship",
         },
         {
-          title: "3. 理解患者的观点",
-          description: "3. 理解患者的观点",
+          title: "3. Understanding the patient's perspective",
+          description: "3. Understanding the patient's perspective",
         },
         {
-          title: "4. 提供沟通结构",
-          description: "4. 提供沟通结构",
+          title: "4. Structuring the consultation",
+          description: "4. Structuring the consultation",
         },
         {
-          title: "5. 信息传递",
-          description: "5. 信息传递",
+          title: "5. Delivering information",
+          description: "5. Delivering information",
         },
         {
-          title: "6. 信息汇总",
-          description: "6. 信息汇总",
+          title: "6. Summarising information",
+          description: "6. Summarising information",
         },
         {
-          title: "7. 场景 1：解释治疗方案",
-          description: "7. 场景 1：解释治疗方案",
+          title: "7. Scenario 1: Explaining a treatment plan",
+          description: "7. Scenario 1: Explaining a treatment plan",
         },
         {
-          title: "8. 场景 2：讨论诊断",
-          description: "8. 场景 2：讨论诊断",
+          title: "8. Scenario 2: Discussing a diagnosis",
+          description: "8. Scenario 2: Discussing a diagnosis",
         },
         {
-          title: "9. 场景 3：处理具有挑战性的行为",
-          description: "9. 场景 3：处理具有挑战性的行为",
+          title: "9. Scenario 3: Managing challenging behaviour",
+          description: "9. Scenario 3: Managing challenging behaviour",
         },
         {
-          title: "10. 场景 4：解释病情",
-          description: "10. 场景 4：解释病情",
+          title: "10. Scenario 4: Explaining a condition",
+          description: "10. Scenario 4: Explaining a condition",
         },
         {
-          title: "11. 场景 5：讨论手术",
-          description: "11. 场景 5：讨论手术",
+          title: "11. Scenario 5: Discussing surgery",
+          description: "11. Scenario 5: Discussing surgery",
         },
         {
-          title: "12. 场景 6：谈论疼痛",
-          description: "12. 场景 6：谈论疼痛",
+          title: "12. Scenario 6: Talking about pain",
+          description: "12. Scenario 6: Talking about pain",
         },
       ],
     },

--- a/content/programmes/medical-english/en/preparatory-medical-english.ts
+++ b/content/programmes/medical-english/en/preparatory-medical-english.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "本课程为英语水平较为基础（CEFR A2–B1 级）的医疗从业者搭建桥梁，助其向高阶医疗英语课程 过渡。通过结构化模块，学员将在真实临床场景中强化语法、医学词汇及听力技能，重点培养日常医 疗任务中的实用沟通能力，为后续专业学习建立信心与基础。\n\nCEFR (Common European Framework of Reference for Languages，欧洲语言共同参考框架) 国际通用语言能力评估标准，分为 A1（初级）至 C2（精通）六个等级。本课程对应\"A2 可完成简 单问诊\"至\"B1 能处理常规医疗对话\"能力阶段。",
+      body: "This programme bridges healthcare professionals at a foundational English level (CEFR A2–B1) to more advanced medical English training. Through structured modules, learners reinforce grammar, medical vocabulary and listening skills in authentic clinical contexts, with a clear focus on practical communication for everyday clinical tasks — building the confidence and foundation needed for further specialist study.\n\nThe Common European Framework of Reference for Languages (CEFR) is an internationally recognised standard for assessing language proficiency, spanning six levels from A1 (beginner) to C2 (mastery). This programme is aligned with the progression from \"A2 — capable of conducting simple consultations\" to \"B1 — able to handle routine clinical conversations\".",
     },
     {
       type: "value-props",
@@ -34,20 +34,20 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "系统性学习语法应用自信",
-          description: "通过问诊句型、时态结构及情态动词专项训练，掌握查体记录（如\"患者主诉持续性胸痛 3 天\"）、病情解释（如\"药物需饭后服用以减轻胃刺激\"）等场景的精准表达",
+          title: "Confident grammar in clinical use",
+          description: "Targeted practice with consultation sentence patterns, tenses and modal verbs supports precise expression in scenarios such as recording physical findings (e.g. \"the patient reports persistent chest pain for three days\") and explaining treatment (e.g. \"this medication should be taken after meals to reduce gastric irritation\")",
         },
         {
-          title: "构建标准化医学词库",
-          description: "建立全面的医学词汇基础，涵盖解剖术语、诊断标准与操作规范，确保临床文档清晰无误",
+          title: "A standardised medical vocabulary base",
+          description: "Build a comprehensive medical vocabulary foundation covering anatomical terminology, diagnostic criteria and procedural language — ensuring clear, unambiguous clinical documentation",
         },
         {
-          title: "临床听力与应答策略升级",
-          description: "通过 15 种以上常见临床场景（如交班汇报、患者教育对话），提升主动倾听与结构化应答技巧",
+          title: "Clinical listening and response strategies",
+          description: "Develop active listening and structured response skills through more than 15 common clinical scenarios, including handover briefings and patient education dialogue",
         },
         {
-          title: "增强跨科室协作沟通能力",
-          description: "在多学科医疗环境中展现专业沟通自主性，为进阶课程（如医学写作）奠定衔接基础",
+          title: "Stronger inter-departmental collaboration",
+          description: "Build confident professional communication within multidisciplinary teams, laying the groundwork for progression into more advanced programmes such as medical writing",
         },
       ],
     },
@@ -57,23 +57,23 @@ const data: ProgrammeData = {
       display: "grid",
       items: [
         {
-          title: "基础场景实战闭环",
+          title: "Foundational scenario practice loop",
           description: "",
         },
         {
-          title: "语法与句法强化体系",
+          title: "Strengthened grammar and syntax framework",
           description: "",
         },
         {
-          title: "医疗术语场景化学习",
+          title: "Medical terminology learned in context",
           description: "",
         },
         {
-          title: "动态听力实战训练",
+          title: "Dynamic, active listening practice",
           description: "",
         },
         {
-          title: "高仿真情景学习工坊",
+          title: "High-fidelity scenario learning workshops",
           description: "",
         },
       ],
@@ -84,52 +84,52 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 身体与创伤",
-          description: "通过身体部位及创伤相关术语和提问结构，构建基础医学词汇。",
+          title: "1. Body and injury",
+          description: "Build foundational medical vocabulary through body parts, injury-related terminology and question structures.",
         },
         {
-          title: "2. 身体与创伤",
-          description: "通过描述创伤、听力练习和语法精炼，提升身体描述的沟通准确性。",
+          title: "2. Body and injury",
+          description: "Develop accuracy in describing the body through injury descriptions, listening practice and grammar refinement.",
         },
         {
-          title: "3. 症状",
-          description: "通过症状识别、描述练习和细节导向的听力训练，提升症状辨识与解释清晰度。",
+          title: "3. Symptoms",
+          description: "Improve symptom recognition and explanation through descriptive practice and detail-oriented listening tasks.",
         },
         {
-          title: "4. 症状",
-          description: "通过语法训练（过去式 / 现在时）和情景化口语练习，提升症状时间线描述的流畅性。",
+          title: "4. Symptoms",
+          description: "Build fluency in describing symptom timelines through grammar work (past / present tense) and scenario-based speaking practice.",
         },
         {
-          title: "5. 检查及诊断",
-          description: "掌握检查术语和报告语言，以有效讨论医学检测。",
+          title: "5. Examinations and diagnosis",
+          description: "Master examination terminology and reporting language to discuss clinical tests effectively.",
         },
         {
-          title: "6. 检查及诊断",
-          description: "通过语法重点（将来时）和准确性训练，强化结果解释的清晰度。",
+          title: "6. Examinations and diagnosis",
+          description: "Strengthen clarity in explaining results through future-tense grammar and accuracy-focused practice.",
         },
         {
-          title: "7. 治疗与程序",
-          description: "开发逐步流程词汇，用于解释治疗方案。",
+          title: "7. Treatment and procedures",
+          description: "Develop step-by-step procedural vocabulary for explaining treatment plans.",
         },
         {
-          title: "8. 治疗与程序",
-          description: "通过流程术语和语法重点（情态动词），优化医疗指令传达。",
+          title: "8. Treatment and procedures",
+          description: "Refine clinical instruction delivery through procedural language and grammar focus (modal verbs).",
         },
         {
-          title: "9. 设施与设备",
-          description: "掌握医院环境和设备沟通的关键词汇。",
+          title: "9. Facilities and equipment",
+          description: "Master core vocabulary for communicating about hospital environments and equipment.",
         },
         {
-          title: "10. 设施与设备",
-          description: "通过设备相关的口语任务和语法应用，提升职场沟通精确性。",
+          title: "10. Facilities and equipment",
+          description: "Build precision in workplace communication through equipment-based speaking tasks and applied grammar.",
         },
         {
-          title: "11. 复习：创伤与症状",
-          description: "通过创伤和症状管理的综合听说练习，巩固核心技能。",
+          title: "11. Review: Injury and symptoms",
+          description: "Consolidate core skills through integrated listening and speaking practice on injury and symptom management.",
         },
         {
-          title: "12. 复习：检查与诊断",
-          description: "通过高阶实践强化诊断与治疗能力，为进阶医疗英语学习做准备。",
+          title: "12. Review: Examination and diagnosis",
+          description: "Strengthen diagnostic and treatment competence through advanced practice, in preparation for further medical English study.",
         },
       ],
     },

--- a/content/programmes/research-academic/en/medical-research-essentials.ts
+++ b/content/programmes/research-academic/en/medical-research-essentials.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "本课程为医疗从业者量身定制，系统传授医学研究的核心方法论与实战技能，涵盖研究设计、伦理合规、 数据管理及国际化学术沟通。通过模块化学习，学员将掌握从选题设计到论文发表的完整科研链条， 为参与国际合作或独立研究项目奠定坚实基础。",
+      body: "Designed for healthcare professionals, this programme provides systematic training in the core methodology and practical skills of medical research — covering study design, ethics and compliance, data management, and international academic communication. Through modular learning, participants will gain a complete understanding of the research pathway, from topic selection through to publication, building a strong foundation for international collaboration or independent research projects.",
     },
     {
       type: "value-props",
@@ -34,28 +34,28 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "医学研究全流程解析",
-          description: "掌握基础研究、临床研究等类型特点，理解从立项到发表的完整阶段划分",
+          title: "End-to-end overview of medical research",
+          description: "Understand the characteristics of basic and clinical research, and the full pathway from study proposal to publication",
         },
         {
-          title: "研究问题构建与文献综述",
-          description: "精准定位研究空白，系统检索中英文权威论文数据库",
+          title: "Research question formulation and literature review",
+          description: "Identify research gaps with precision and conduct systematic searches across leading English- and Chinese-language journal databases",
         },
         {
-          title: "研究方法设计实战",
-          description: "根据研究目标选择随机对照试验（RCT）、队列研究等设计，规避常见方法学误区",
+          title: "Practical study design",
+          description: "Select appropriate designs — including randomised controlled trials (RCTs) and cohort studies — to match research objectives, while avoiding common methodological pitfalls",
         },
         {
-          title: "伦理与合规管理",
-          description: "熟悉知情同意书撰写、伦理委员会申报流程及数据隐私保护规范",
+          title: "Ethics and compliance",
+          description: "Become familiar with informed consent drafting, ethics committee submission processes, and data privacy protection standards",
         },
         {
-          title: "数据分析与结果解读",
-          description: "学习数据处理与分析基础操作，掌握图表制作与统计学意义阐释",
+          title: "Data analysis and interpretation",
+          description: "Learn foundational data processing and analysis, and master figure preparation and statistical significance interpretation",
         },
         {
-          title: "英文论文读写进阶",
-          description: "精研 IMRAD 结构，强化摘要写作与国际期刊常用表达",
+          title: "Advanced English academic reading and writing",
+          description: "Develop a strong command of the IMRAD structure, strengthen abstract writing, and master the standard language used in international journals",
         },
       ],
     },
@@ -65,24 +65,24 @@ const data: ProgrammeData = {
       display: "timeline",
       items: [
         {
-          title: "国际师资团队",
-          description: "由医学英语专家、研究方法论学者及 SCI 期刊审稿人联合授课",
+          title: "International teaching team",
+          description: "Co-delivered by medical English specialists, research methodology scholars and SCI journal reviewers",
         },
         {
-          title: "真实案例库",
-          description: "解析医学顶刊论文的写作逻辑和实际案例分析",
+          title: "Real-world case library",
+          description: "Analyse the writing logic and practical case studies behind papers published in leading medical journals",
         },
         {
-          title: "带教式训练",
-          description: "分步骤指导文献精读、数据描述与讨论部分撰写",
+          title: "Mentor-style training",
+          description: "Step-by-step guidance on close reading of literature, data description and writing the discussion section",
         },
         {
-          title: "语言强化包",
-          description: "提供医学高频词汇表、连接词库及常见语法错误避坑指南",
+          title: "Language reinforcement pack",
+          description: "Includes a high-frequency medical vocabulary list, connectives bank and a guide to common grammar pitfalls",
         },
         {
-          title: "结业考核",
-          description: "完成一份研究方案展示或论文摘要，获得专家认证证书",
+          title: "Final assessment",
+          description: "Present a research proposal or paper abstract to receive an expert-certified completion certificate",
         },
       ],
     },
@@ -92,28 +92,28 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 医学研究导论：从理论到实践",
-          description: "1. 医学研究导论：从理论到实践",
+          title: "1. Introduction to medical research: from theory to practice",
+          description: "1. Introduction to medical research: from theory to practice",
         },
         {
-          title: "2. 研究问题构建与文献综述实战",
-          description: "2. 研究问题构建与文献综述实战",
+          title: "2. Research question formulation and literature review in practice",
+          description: "2. Research question formulation and literature review in practice",
         },
         {
-          title: "3. 研究设计与方法学精要",
-          description: "3. 研究设计与方法学精要",
+          title: "3. Study design and methodology essentials",
+          description: "3. Study design and methodology essentials",
         },
         {
-          title: "4. 伦理合规与科研管理",
-          description: "4. 伦理合规与科研管理",
+          title: "4. Ethics, compliance and research governance",
+          description: "4. Ethics, compliance and research governance",
         },
         {
-          title: "5. 数据收集 & 分析全教程",
-          description: "5. 数据收集 & 分析全教程",
+          title: "5. Data collection and analysis — full walkthrough",
+          description: "5. Data collection and analysis — full walkthrough",
         },
         {
-          title: "6. 国际期刊论文读写精修",
-          description: "6. 国际期刊论文读写精修",
+          title: "6. Reading and writing for international journals",
+          description: "6. Reading and writing for international journals",
         },
       ],
     },

--- a/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
+++ b/content/programmes/research-academic/en/medical-writing-publication-bootcamp.ts
@@ -26,7 +26,7 @@ const data: ProgrammeData = {
     {
       type: "intro",
       title: "Course Overview",
-      body: "医学写作与发表强化训练营，致力于系统化提升国际医学论文写作与发表能力。",
+      body: "An intensive bootcamp designed to systematically strengthen the skills required to write and publish medical research papers in international journals.",
     },
     {
       type: "value-props",
@@ -34,23 +34,23 @@ const data: ProgrammeData = {
       display: "list",
       items: [
         {
-          title: "系统掌握国际医学出版全流程（SCI/SSCI/Medline 标准），包括论文评审机制与行业规范",
+          title: "Gain a systematic understanding of the international medical publication process (SCI / SSCI / Medline standards), including peer-review mechanisms and disciplinary conventions",
           description: "",
         },
         {
-          title: "深入解析国际医学期刊文章的核心结构、写作惯例与文体特征，提升学术表达的精准度",
+          title: "Develop a deep understanding of the core structure, writing conventions and stylistic features of international medical journal articles, building precision in academic expression",
           description: "",
         },
         {
-          title: "强化医学研究写作中的学术英语能力，攻克语法、术语与句式难点",
+          title: "Strengthen academic English for medical research writing, addressing common challenges with grammar, terminology and sentence structure",
           description: "",
         },
         {
-          title: "掌握数据可视化呈现、逻辑链构建及科学叙事技巧，打造高影响力的医学论文",
+          title: "Master data visualisation, logical argumentation and scientific narrative techniques to produce high-impact medical papers",
           description: "",
         },
         {
-          title: "实战演练期刊筛选、稿件投递及审稿意见回复策略，全面提升发表成功率",
+          title: "Practise journal selection, manuscript submission and responding to reviewer comments — improving overall publication success",
           description: "",
         },
       ],
@@ -61,28 +61,28 @@ const data: ProgrammeData = {
       display: "grid",
       items: [
         {
-          title: "系统性写作进阶框架",
-          description: "从选题设计到论文发表的全程方法论指导",
+          title: "A systematic writing progression framework",
+          description: "End-to-end methodology guidance from topic selection through to publication",
         },
         {
-          title: "医学学术英语精修",
-          description: "破解\"中式英语\"陷阱，学习高频学术表达与精准术语应用",
+          title: "Refined academic medical English",
+          description: "Break out of \"Chinglish\" pitfalls and master high-frequency academic phrasing and precise terminology",
         },
         {
-          title: "期刊匹配精准导航",
-          description: "基于研究领域、影响力与审稿周期，瞄准合适期刊发表",
+          title: "Targeted journal matching",
+          description: "Identify the right journals based on research field, impact factor and review timelines",
         },
         {
-          title: "智能工具赋能写作",
-          description: "实战演练 AI 工具辅助写作，提升语法校对、文献管理与效率",
+          title: "AI tools to support your writing",
+          description: "Hands-on practice with AI-assisted writing, grammar checking, reference management and efficiency tools",
         },
         {
-          title: "真实案例深度剖析",
-          description: "对比分析高分论文与典型拒稿案例，提炼可复制的成功要素",
+          title: "In-depth case analysis",
+          description: "Compare published high-impact papers with common rejection cases to extract repeatable success factors",
         },
         {
-          title: "个性化专家反馈",
-          description: "针对学员初稿提供逐行批注与修改建议，加速论文优化进程",
+          title: "Personalised expert feedback",
+          description: "Line-by-line annotation and editing suggestions on participant drafts to accelerate revision",
         },
       ],
     },
@@ -92,28 +92,28 @@ const data: ProgrammeData = {
       display: "table",
       items: [
         {
-          title: "1. 中国医生国际发表困境解析",
-          description: "1. 中国医生国际发表困境解析",
+          title: "1. Common challenges faced by Chinese clinicians publishing internationally",
+          description: "1. Common challenges faced by Chinese clinicians publishing internationally",
         },
         {
-          title: "2. SCI 发表的核心逻辑与实战策略",
-          description: "2. SCI 发表的核心逻辑与实战策略",
+          title: "2. The core logic and practical strategies of SCI publication",
+          description: "2. The core logic and practical strategies of SCI publication",
         },
         {
-          title: "3. 医学论文解构与写作精要（IMRaD 框架）",
-          description: "3. 医学论文解构与写作精要（IMRaD 框架）",
+          title: "3. Deconstructing the medical paper: writing essentials and the IMRaD framework",
+          description: "3. Deconstructing the medical paper: writing essentials and the IMRaD framework",
         },
         {
-          title: "4. 学术英语写作体系精讲",
-          description: "4. 学术英语写作体系精讲",
+          title: "4. A structured walkthrough of academic English writing",
+          description: "4. A structured walkthrough of academic English writing",
         },
         {
-          title: "5. 投稿材料准备与审稿沟通实战",
-          description: "5. 投稿材料准备与审稿沟通实战",
+          title: "5. Submission package preparation and reviewer communication in practice",
+          description: "5. Submission package preparation and reviewer communication in practice",
         },
         {
-          title: "6. 案例解析与写作实战工作坊",
-          description: "6. 案例解析与写作实战工作坊",
+          title: "6. Case analysis and writing workshop",
+          description: "6. Case analysis and writing workshop",
         },
       ],
     },


### PR DESCRIPTION
巡视 5/21 发现 #109 远超预期: 8 门 en 课程数据文件里 7 门塞满中文, /en 路径下整页几乎全中文.

Moss 直接翻译 (LLM, 质量约 80%, 章逊后续抽查改). 风格对标 NHS / Cambridge / OET, 克制专业.

| 文件 | 翻译前 CJK | 翻译后 |
|---|---|---|
| preparatory-medical-english | 761 | 0 |
| medical-humanities-general-practice | 655 | 0 |
| pre-departure-medical-english | 647 | 0 |
| medical-research-essentials | 572 | 0 |
| medical-writing-publication-bootcamp | 514 | 0 |
| medical-english-for-nurses | 500 | 0 |
| medical-english-for-doctors | 417 | 0 |
| medical-humanities-communication-skills | 327 | 0 |

红线: 没碰 zh-CN, 没改结构/键名, tsc 通过. Refs: #109