### PR TITLE
feat(contact): 联系页增加全球时间控件

### DIFF
--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { Mail, Phone, MapPin, Clock } from "lucide-react";
 import { HeroSection } from "@/components/ui/hero-section";
 import { FadeIn } from "@/components/ui/fade-in";
+import { WorldClock } from "@/components/ui/world-clock";
 
 const CONTACT_INFO = [
   { icon: Phone, key: "phone", value: "+44 (0)7345 169 054" },
@@ -90,6 +91,11 @@ export default function ContactPage() {
                   <p className="text-sm text-[#00438A] font-medium">
                     {t("info.tagline")}
                   </p>
+                </div>
+
+                {/* World Clock */}
+                <div className="mt-6">
+                  <WorldClock />
                 </div>
               </div>
             </FadeIn>

--- a/src/components/ui/world-clock.tsx
+++ b/src/components/ui/world-clock.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
+
+interface CityTime {
+  key: string;
+  flag: string;
+  timezone: string;
+}
+
+const CITIES: CityTime[] = [
+  { key: "china", flag: "🇨🇳", timezone: "Asia/Shanghai" },
+  { key: "uk", flag: "🇬🇧", timezone: "Europe/London" },
+  { key: "canada", flag: "🇨🇦", timezone: "America/Toronto" },
+  { key: "australia", flag: "🇦🇺", timezone: "Australia/Sydney" },
+];
+
+function formatTime(timezone: string): string {
+  return new Intl.DateTimeFormat("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: timezone,
+    hour12: false,
+  }).format(new Date());
+}
+
+function isWorkingHours(timezone: string): boolean {
+  const hour = parseInt(
+    new Intl.DateTimeFormat("en-GB", {
+      hour: "numeric",
+      timeZone: timezone,
+      hour12: false,
+    }).format(new Date()),
+    10
+  );
+  return hour >= 9 && hour < 18;
+}
+
+export function WorldClock() {
+  const t = useTranslations("contact.worldClock");
+  const [times, setTimes] = useState<Record<string, string>>({});
+  const [working, setWorking] = useState<Record<string, boolean>>({});
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    setMounted(true);
+
+    function tick() {
+      const newTimes: Record<string, string> = {};
+      const newWorking: Record<string, boolean> = {};
+      for (const city of CITIES) {
+        newTimes[city.key] = formatTime(city.timezone);
+        newWorking[city.key] = isWorkingHours(city.timezone);
+      }
+      setTimes(newTimes);
+      setWorking(newWorking);
+    }
+
+    tick();
+    const interval = setInterval(tick, 30_000); // refresh every 30s
+    return () => clearInterval(interval);
+  }, []);
+
+  if (!mounted) {
+    // SSG placeholder — avoid hydration mismatch
+    return (
+      <div className="rounded-xl border border-[#E3E5EC] bg-[#F8F9FC] p-5">
+        <p className="text-sm text-[#3C3A47]">{t("title")}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-[#E3E5EC] bg-[#F8F9FC] p-5">
+      <p className="text-xs font-semibold uppercase tracking-wider text-[#00438A] mb-3">
+        {t("title")}
+      </p>
+      <div className="grid grid-cols-2 gap-3">
+        {CITIES.map((city) => (
+          <div
+            key={city.key}
+            className="flex items-center gap-2.5 rounded-lg bg-white px-3 py-2.5 border border-[#E3E5EC]"
+          >
+            <span className="text-lg leading-none">{city.flag}</span>
+            <div className="min-w-0 flex-1">
+              <p className="text-xs text-[#3C3A47] truncate">{t(city.key)}</p>
+              <p className="text-sm font-semibold text-[#0A1628] tabular-nums">
+                {times[city.key] ?? "--:--"}
+              </p>
+            </div>
+            {working[city.key] && (
+              <span
+                className="h-2 w-2 rounded-full bg-emerald-500 shrink-0"
+                title={t("online")}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+      <p className="mt-3 text-[11px] text-[#3C3A47]/70 leading-relaxed">
+        {t("hint")}
+      </p>
+    </div>
+  );
+}

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -632,6 +632,15 @@
       "email": "Email",
       "message": "Message",
       "submit": "Send"
+    },
+    "worldClock": {
+      "title": "Office Hours Worldwide",
+      "china": "Beijing",
+      "uk": "London",
+      "canada": "Toronto",
+      "australia": "Sydney",
+      "online": "Currently in working hours",
+      "hint": "Green dot indicates the region is currently within working hours (9:00–18:00). We typically respond within 24 hours during business hours."
     }
   },
   "insightDetail": {

--- a/src/messages/zh-CN.json
+++ b/src/messages/zh-CN.json
@@ -632,6 +632,15 @@
       "email": "邮箱",
       "message": "留言内容",
       "submit": "发送"
+    },
+    "worldClock": {
+      "title": "全球办公时间",
+      "china": "北京",
+      "uk": "伦敦",
+      "canada": "多伦多",
+      "australia": "悉尼",
+      "online": "工作时间中",
+      "hint": "绿色圆点表示该地区当前处于工作时间（9:00-18:00），我们通常在工作时间内 24 小时内回复。"
     }
   },
   "insightDetail": {


### PR DESCRIPTION
## 变更

- 在 Contact 页左侧信息卡加入全球时间控件
- 显示北京 / 伦敦 / 多伦多 / 悉尼当前时间
- 每 30 秒刷新，绿色圆点标注当前处于 9:00-18:00 工作时间的地区
- 中英文 i18n 文案已补齐

## 验证

- npm run typecheck ✅
- npm run build ✅（构建通过；现有 insights.readMore missing message 噪音非本 PR 引入）

## 设计说明

纯前端 Intl.DateTimeFormat 实现，不引入第三方 widget / 新依赖；SSR 阶段渲染占位，避免 hydration mismatch。